### PR TITLE
Remove owner and user collection reads

### DIFF
--- a/commands/hub/info.js
+++ b/commands/hub/info.js
@@ -5,11 +5,7 @@ const grvAcnt = '`';
 const sendInfoEmbed = function designOfYagiInformationEmbed(message, yagi, yagiPrefix) {
   const embed = {
     title: 'Info',
-    description: `Hi there! I'm Yagi and I provide information for the world bosses of Vulture's Vale and Blizzard Berg in Aura Kingdom EN!\n\nInitially my creator only wanted to make a [website](https://ak-goats.com/) but eventually opted to make a discord version as well! Since then I'm currently serving ${
-      yagi.users.size
-    } people in ${
-      yagi.guilds.size
-    } servers!\n\nMy timer data is extracted from the player-run [Olympus WB Sheet](https://docs.google.com/spreadsheets/d/tUL0-Nn3Jx7e6uX3k4_yifQ/edit#gid=585652389). Kudos to the hardwork of the editors and leads in the team!\n\nMy prefix  is ${grvAcnt}${yagiPrefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${yagiPrefix}help${grvAcnt}`,
+    description: `Hi there! I'm Yagi and I provide information for the world bosses of Vulture's Vale and Blizzard Berg in Aura Kingdom EN!\n\nInitially my creator only wanted to make a [website](https://ak-goats.com/) but eventually opted to make a discord version as well! Since then I'm currently serving ${yagi.guilds.size} servers!\n\nMy timer data is extracted from the player-run [Olympus WB Sheet](https://docs.google.com/spreadsheets/d/tUL0-Nn3Jx7e6uX3k4_yifQ/edit#gid=585652389). Kudos to the hardwork of the editors and leads in the team!\n\nMy prefix  is ${grvAcnt}${yagiPrefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${yagiPrefix}help${grvAcnt}`, //Removed users for now
     color: 32896,
     thumbnail: {
       url:

--- a/helpers.js
+++ b/helpers.js
@@ -136,11 +136,11 @@ const serverEmbed = function designOfEmbedForShowingYagiJoiningAndLeavingServer(
         value: guild.name,
         inline: true,
       },
-      {
-        name: 'Owner',
-        value: guild.owner.user.tag,
-        inline: true,
-      },
+      // {
+      //   name: 'Owner',
+      //   value: guild.owner.user.tag,
+      //   inline: true,
+      // },
       {
         name: 'Members',
         value: guild.memberCount,

--- a/helpers.js
+++ b/helpers.js
@@ -125,7 +125,7 @@ const serverEmbed = function designOfEmbedForShowingYagiJoiningAndLeavingServer(
   }
   const embed = {
     title: embedTitle,
-    description: `I'm now in **${yagi.guilds.size}** servers and serving **${yagi.users.size}** users!`,
+    description: `I'm now in **${yagi.guilds.size}** servers!`, //Removed users for now
     color: embedColor,
     thumbnail: {
       url: guild.iconURL ? guild.iconURL.replace(/jpeg|jpg/gi, 'png') : defaultIcon,

--- a/yagi.js
+++ b/yagi.js
@@ -34,9 +34,15 @@ yagi.once('ready', () => {
   yagi.guilds.forEach((guild) => {
     console.log(`${guild.name} - ${guild.region} : ${guild.memberCount}`);
   });
-  console.log(`Number of users: ${yagi.users.size}\nNumber of guilds: ${yagi.guilds.size}`);
+  console.log(`Number of guilds: ${yagi.guilds.size}`);
   //Saves guild data if it's not in file
   yagi.guilds.forEach((guild) => {
+    /**
+     * IMPORTANT
+     * It seems that the member and user collections are not accessible.
+     * Not too sure how to fix for now, maybe updating discord.js to v12? Glancing through the release notes it looks like there would be a lot of breaking changes if I update
+     * Either way, I'll remove all instances of them for now
+     */
     if (!guildConfig[guild.id]) {
       guildConfig[guild.id] = {
         name: guild.name,
@@ -49,7 +55,7 @@ yagi.once('ready', () => {
       const embed = serverEmbed(yagi, guild, 'join');
       const serversChannel = yagi.channels.get('614749682849021972');
       serversChannel.send({ embed });
-      serversChannel.setTopic(`Servers: ${yagi.guilds.size} | Users: ${yagi.users.size}`);
+      serversChannel.setTopic(`Servers: ${yagi.guilds.size}`);
     }
   });
   console.log(guildConfig);
@@ -92,7 +98,7 @@ yagi.on('guildCreate', (guild) => {
     const embed = serverEmbed(yagi, guild, 'join');
     const serversChannel = yagi.channels.get('614749682849021972');
     serversChannel.send({ embed });
-    serversChannel.setTopic(`Servers: ${yagi.guilds.size} | Users: ${yagi.users.size}`);
+    serversChannel.setTopic(`Servers: ${yagi.guilds.size}`); //Removed users for now
   });
 });
 
@@ -107,7 +113,7 @@ yagi.on('guildDelete', (guild) => {
     const embed = serverEmbed(yagi, guild, 'leave');
     const serversChannel = yagi.channels.get('614749682849021972');
     serversChannel.send({ embed });
-    serversChannel.setTopic(`Servers: ${yagi.guilds.size} | Users: ${yagi.users.size}`);
+    serversChannel.setTopic(`Servers: ${yagi.guilds.size}`); //Removed users for now
   });
 });
 yagi.on('message', async (message) => {

--- a/yagi.js
+++ b/yagi.js
@@ -40,7 +40,7 @@ yagi.once('ready', () => {
     if (!guildConfig[guild.id]) {
       guildConfig[guild.id] = {
         name: guild.name,
-        owner: guild.owner.user.tag,
+        // owner: guild.owner.user.tag,
         memberCount: guild.memberCount,
         region: guild.region,
         prefix: defaultPrefix,
@@ -79,7 +79,7 @@ yagi.on('ready', () => {
 yagi.on('guildCreate', (guild) => {
   guildConfig[guild.id] = {
     name: guild.name,
-    owner: guild.owner.user.tag,
+    // owner: guild.owner.user.tag,
     memberCount: guild.memberCount,
     region: guild.region,
     prefix: defaultPrefix,


### PR DESCRIPTION
#### Context
Apparently you can't directly get data from these collections now (?). Not entirely sure what's the cause of it yet but taking a glance at discord.js docs, there seems to be changes in their versions. Updating to the latest would probably be the best course of action but that would mean needing to fix breaking changes that comes with it. Not really too keen in doing that yet so I'll just remove these for now and see if I have bandwidth to update version later.

#### Change
- Remove owner and user collections

#### Release Notes
Temporarily remove user and guild owner instances