### PR TITLE
Add dev update to info embed

### DIFF
--- a/commands/hub/info.js
+++ b/commands/hub/info.js
@@ -31,6 +31,10 @@ const sendInfoEmbed = function designOfYagiInformationEmbed(message, yagi, yagiP
         name: 'Library',
         value: 'discord.js',
         inline: true
+      },
+      {
+        name: 'Dev Update | 26 Jan 2021',
+        value: `Happy 2021! Man I can't believe I had yagi down for half a year, so much has happened in 2020 that I just forgot and lost motivation in this project. But hey, it's a new year which means a new start! Won't go in detail here in what I have planned but for now, my first priority is to get this guy up and running again.`
       }
     ]
   };


### PR DESCRIPTION
#### Context
Since I basically decommissioned yagi for half a year unexpectedly without letting anyone know, thought it would be a good idea to add a dev update to let users know what I'm planning for yagi. Would probably have this as a separate command (maybe change release command to dev update?) but for the sake of getting this out there, I'll leave it in info for now

#### Change
- Add dev update

#### Release Notes
Add dev update in info command