### PR TITLE
Release/26 01 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# v2.2.0 (Tue Jan 26 2021)
+
+### Release Notes
+
+#### Update README.md ([#41](https://github.com/vexuas/yagi/pull/41))
+
+Update readme
+
+#### Add dev update to info embed ([#40](https://github.com/vexuas/yagi/pull/40))
+
+Add dev update in info command
+
+#### Update offset ([#39](https://github.com/vexuas/yagi/pull/39))
+
+Update offset to reflect daylight savings
+
+#### Remove owner and user collection reads ([#38](https://github.com/vexuas/yagi/pull/38))
+
+Temporarily remove user and guild owner instances
+
+#### Install nodemon ([#37](https://github.com/vexuas/yagi/pull/37))
+
+Install nodemon
+
+#### Install auto ([#36](https://github.com/vexuas/yagi/pull/36))
+
+Install auto
+
+---
+
+#### 🚀 Enhancement
+
+- Update README.md [#41](https://github.com/vexuas/yagi/pull/41) ([@vexuas](https://github.com/vexuas))
+- Add dev update to info embed [#40](https://github.com/vexuas/yagi/pull/40) ([@vexuas](https://github.com/vexuas))
+- Update offset [#39](https://github.com/vexuas/yagi/pull/39) ([@vexuas](https://github.com/vexuas))
+- Remove owner and user collection reads [#38](https://github.com/vexuas/yagi/pull/38) ([@vexuas](https://github.com/vexuas))
+- Install nodemon [#37](https://github.com/vexuas/yagi/pull/37) ([@vexuas](https://github.com/vexuas))
+- Install auto [#36](https://github.com/vexuas/yagi/pull/36) ([@vexuas](https://github.com/vexuas))
+
+#### 🐛 Bug Fix
+
+- Release/2.1.1 [#32](https://github.com/vexuas/yagi/pull/32) ([@vexuas](https://github.com/vexuas))
+
+#### 🔩 Dependency Updates
+
+- Bump googleapis from 27.0.0 to 39.1.0 [#34](https://github.com/vexuas/yagi/pull/34) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+- Bump lodash from 4.17.15 to 4.17.19 [#33](https://github.com/vexuas/yagi/pull/33) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+- Bump https-proxy-agent from 2.2.1 to 2.2.4 [#29](https://github.com/vexuas/yagi/pull/29) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+
+#### Authors: 2
+
+- [@dependabot[bot]](https://github.com/dependabot[bot])
+- Gabriel R ([@vexuas](https://github.com/vexuas))

--- a/commands/hub/release.js
+++ b/commands/hub/release.js
@@ -2,9 +2,9 @@ module.exports = {
   name: 'release',
   description: 'Displays the latest version information and changelog',
   execute(message) {
-    const release = '```\n• Revert server time`\n• Show current prefix when pinged``';
+    const release = '```Tbh just a lot of internal updates. Gonna see if I can make this release command more efficient in the coming weeks```';
     const embed = {
-      description: `${message.author} | Latest Release: [v2.1.1](https://github.com/Vexuas/yagi/releases)\n${release}`,
+      description: `${message.author} | Latest Release: [v2.2.0](https://github.com/Vexuas/yagi/releases)\n${release}`,
       color: 32896,
     };
     message.channel.send({ embed });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yagi",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Vulture's Vale/Blizzard Berg World Boss Timer for Aura Kingdom",
   "main": "yagi.js",
   "author": "Vexuas",


### PR DESCRIPTION
# v2.2.0 (Tue Jan 26 2021)

#### 🚀 Enhancement

- Update README.md [#41](https://github.com/vexuas/yagi/pull/41) ([@vexuas](https://github.com/vexuas))
- Add dev update to info embed [#40](https://github.com/vexuas/yagi/pull/40) ([@vexuas](https://github.com/vexuas))
- Update offset [#39](https://github.com/vexuas/yagi/pull/39) ([@vexuas](https://github.com/vexuas))
- Remove owner and user collection reads [#38](https://github.com/vexuas/yagi/pull/38) ([@vexuas](https://github.com/vexuas))
- Install nodemon [#37](https://github.com/vexuas/yagi/pull/37) ([@vexuas](https://github.com/vexuas))
- Install auto [#36](https://github.com/vexuas/yagi/pull/36) ([@vexuas](https://github.com/vexuas))

#### 🐛 Bug Fix

- Release/2.1.1 [#32](https://github.com/vexuas/yagi/pull/32) ([@vexuas](https://github.com/vexuas))

#### 🔩 Dependency Updates

- Bump googleapis from 27.0.0 to 39.1.0 [#34](https://github.com/vexuas/yagi/pull/34) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
- Bump lodash from 4.17.15 to 4.17.19 [#33](https://github.com/vexuas/yagi/pull/33) ([@dependabot[bot]](https://github.com/dependabot[bot]))
- Bump https-proxy-agent from 2.2.1 to 2.2.4 [#29](https://github.com/vexuas/yagi/pull/29) ([@dependabot[bot]](https://github.com/dependabot[bot]))

#### Authors: 2

- [@dependabot[bot]](https://github.com/dependabot[bot])
- Gabriel R ([@vexuas](https://github.com/vexuas))