### PR TITLE
Add temporary warning to custom prefix command

### DIFF
--- a/commands/misc/prefix.js
+++ b/commands/misc/prefix.js
@@ -35,6 +35,9 @@ module.exports = {
   hasArguments: true,
   exampleArgument: '$',
   execute(message, arguments) {
+    if(message){
+      return message.channel.send(`Sorry there's something wrong with this command for now (◕︿◕✿) Currently working on a fix, will get it up and running next patch!`)
+    }
     const currentPrefix = guildConfig[message.guild.id].prefix;
     /**
      * First logic sends default prefix embed


### PR DESCRIPTION
#### Context
Apparently trying to change the prefix to a custom one doesn't work anymore. Threw this `Cannot read property 'hasPermission' of null` error which is probably the same reason why calling guilds and users doesn't work. For now adding a temporary warning if users try to use this command, will try to investigate more on why this is happening but I have a feeling I probably need to update discord js to the newer versions.

#### Change
- Add temporary warning if users try to use the prefix command

#### Release Notes
Add temporary warning to the prefix command