### PR TITLE
Add PSA command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 # config
 /config/guild.json
 /config/yagi.json
+/config/psa.json
 
 # system files
 .DS_Store

--- a/commands.js
+++ b/commands.js
@@ -17,6 +17,7 @@ module.exports = {
   message: require('./commands/developer/message'),
   daylights: require('./commands/developer/daylights'),
   offset: require('./commands/developer/offset'),
+  psa: require('./commands/developer/psa'),
   // Hub
   // ----------
   info: require('./commands/hub/info'),

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -8,49 +8,64 @@ const startPSA = (message, messageInfo) => {
   //Checks what message to show to user
   // if()
 }
-
+/**
+ * Turns off PSA
+ * Also switches the message back to the default one
+ */
 const stopPSA = (message) => {
   if(!PSA){
-    return message.channel.send('PSA is already turned off');
+    const embed = generateEmbed('stop', 'PSA is already turned off!');
+    return message.channel.send({ embed });
   }
   const updatedPSAInfo = {
     PSA: false,
     PSAmessage: defaultMessage
   }
+
   fs.writeFile('./config/psa.json', JSON.stringify(updatedPSAInfo, null, 2), function (err) {
     if (err) {
       return console.log(err);
     }
-    return message.channel.send('Turned off PSA');
+    const embed = generateEmbed('stop', null, updatedPSAInfo);
+    message.channel.send({ embed });
   });
 }
 /**
  * Shows if PSA is activated
  **/
 const showPSA = (message) => {
-  const showMessage = PSA ? 'PSA is turned on' : 'PSA is turned off';
-  return message.channel.send(showMessage);
+  const embed = generateEmbed('show');
+  return message.channel.send({ embed });
 }
 
-// const generateEmbed = (type) => {
-//   if(type){
+const generateEmbed = (type, descriptionInfo, updatedInfo) => {
+  let description;
+  const PSAtext = PSA ? 'On' : 'Off';
+  const updatedPSAtext = updatedInfo.PSA ? 'On' : 'Off';
 
-//   }
-//   const embed = {
-//     color: 32896,
-//     fields: [
-//       {
-//         name: 'PSA',
-//         value: PSA ? 'on' : 'off'
-//       },
-//       {
-//         name: 'PSA Message',
-//         value: PSAmessage
-//       }
-//     ]
-//   }
-//   return embed;
-// }
+  switch(type){
+    case 'show':
+    description = PSA ? 'PSA is turned on' : 'PSA is turned off';
+    break;
+    case 'stop':
+    description = descriptionInfo ? descriptionInfo : 'Turned off PSA!';
+  }
+  const embed = {
+    description,
+    color: 32896,
+    fields: [
+      {
+        name: 'PSA',
+        value: updatedInfo ? updatedPSAtext : PSAtext
+      },
+      {
+        name: 'PSA Message',
+        value: PSAmessage
+      }
+    ]
+  }
+  return embed;
+}
 module.exports = {
   name: "psa",
   description: "Toggles a trigger that sends a public service announcement when using the timer. Only to be used in extreme cases where timer data is experiencing problems",

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -1,7 +1,7 @@
 const { PSA, PSAmessage } = require('../../config/psa.json');
 const fs = require('fs');
 
-const defaultMessage = "Oopsie!"
+const defaultMessage = "There looks to be a problem with the timer at the moment, sorry! （・□・；)"
 
 /**
  * Shows if PSA is activated

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -1,0 +1,11 @@
+module.exports = {
+  name: "psa",
+  description: "Toggles a trigger that sends a public service announcement when using the timer. Only to be used in extreme cases where timer data is experiencing problems",
+  devOnly: true,
+  async execute(message) {
+    if (message.author.id === '183444648360935424') {
+      return message.channel.send({ embed });
+    }
+    return;
+  }
+};

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -3,11 +3,21 @@ const fs = require('fs');
 
 const defaultMessage = "Oopsie!"
 
+/**
+ * Shows if PSA is activated
+ */
+const showPSA = (message) => {
+  const embed = generateEmbed('show');
+  return message.channel.send({ embed });
+}
+//-----
+
 const startPSA = (message, messageInfo) => {
   let psa;
   //Checks what message to show to user
   // if()
 }
+//-----
 /**
  * Turns off PSA
  * Also switches the message back to the default one
@@ -30,14 +40,13 @@ const stopPSA = (message) => {
     message.channel.send({ embed });
   });
 }
+//-----
 /**
- * Shows if PSA is activated
- **/
-const showPSA = (message) => {
-  const embed = generateEmbed('show');
-  return message.channel.send({ embed });
-}
-
+ * Reusable embed to use for this command
+ * @param {string} type - whether argument is show, start, stop
+ * @param {string} descriptionInfo - if we want to add a custom description
+ * @param {object} updatedInfo - additional updated info to display
+ */
 const generateEmbed = (type, descriptionInfo, updatedInfo) => {
   let description;
   const PSAtext = PSA ? 'On' : 'Off';

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -17,7 +17,6 @@ const showPSA = (message) => {
  * @param {string} customPSA - optional message if you want to change the message of the PSA
  */
 const startPSA = (message, customPSA) => {
-  console.log('start')
   if(PSA){
     const embed = generateEmbed('start', 'PSA is already turned on!');
     return message.channel.send({ embed });

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -1,10 +1,37 @@
+const { PSA, PSAmessage } = require('../../config/psa.json');
+
+const setPSA = (message, messageInfo, show) => {
+  if(show){
+    const showMessage = PSA ? 'PSA is turned on' : 'PSA is turned off'
+    
+  }
+  let psa;
+  //Toggles PSA
+  if(PSA){
+    psa = false;
+  } else {
+    psa = true;
+  }
+  //Checks what message to show to user
+  // if()
+}
+
+/**
+ * Shows if PSA is activated
+ */
+const showPSA = (message) => {
+  const showMessage = PSA ? 'PSA is turned on' : 'PSA is turned off';
+  return message.channel.send(showMessage);
+}
+
 module.exports = {
   name: "psa",
   description: "Toggles a trigger that sends a public service announcement when using the timer. Only to be used in extreme cases where timer data is experiencing problems",
   devOnly: true,
   async execute(message) {
     if (message.author.id === '183444648360935424') {
-      return message.channel.send({ embed });
+      return showPSA(message);
+      // return setPSA(message, 'Hello', true);
     }
     return;
   }

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -17,6 +17,7 @@ const showPSA = (message) => {
  * @param {string} customPSA - optional message if you want to change the message of the PSA
  */
 const startPSA = (message, customPSA) => {
+  console.log('start')
   if(PSA){
     const embed = generateEmbed('start', 'PSA is already turned on!');
     return message.channel.send({ embed });
@@ -99,11 +100,20 @@ const generateEmbed = (type, descriptionInfo, updatedInfo) => {
 module.exports = {
   name: "psa",
   description: "Toggles a trigger that sends a public service announcement when using the timer. Only to be used in extreme cases where timer data is experiencing problems",
+  hasArguments: true,
   devOnly: true,
-  async execute(message) {
+  async execute(message, arguments) {
     if (message.author.id === '183444648360935424') {
-      return startPSA(message, 'Lets gooo');
-      // return setPSA(message, 'Hello', true);
+      const type = arguments.split(' ', 1).toString();
+      switch(type){
+        case 'show':
+          return showPSA(message);
+        case 'start':
+          const customMessage = arguments.slice(type.length + 1);
+          return startPSA(message, customMessage);
+        case 'stop':
+          return stopPSA(message);
+      }
     }
     return;
   }

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -11,11 +11,28 @@ const showPSA = (message) => {
   return message.channel.send({ embed });
 }
 //-----
+/**
+ * Turns on the PSA
+ * This would send the PSA message when users try to use the goat timer
+ * @param {string} customPSA - optional message if you want to change the message of the PSA
+ */
+const startPSA = (message, customPSA) => {
+  if(PSA){
+    const embed = generateEmbed('start', 'PSA is already turned on!');
+    return message.channel.send({ embed });
+  }
+  const updatedPSAInfo = {
+    PSA: true,
+    PSAmessage: customPSA ? customPSA : defaultMessage
+  }
 
-const startPSA = (message, messageInfo) => {
-  let psa;
-  //Checks what message to show to user
-  // if()
+  fs.writeFile('./config/psa.json', JSON.stringify(updatedPSAInfo, null, 2), function (err) {
+    if (err) {
+      return console.log(err);
+    }
+    const embed = generateEmbed('start', null, updatedPSAInfo);
+    message.channel.send({ embed });
+  });
 }
 //-----
 /**
@@ -54,10 +71,14 @@ const generateEmbed = (type, descriptionInfo, updatedInfo) => {
 
   switch(type){
     case 'show':
-    description = PSA ? 'PSA is turned on' : 'PSA is turned off';
-    break;
+      description = PSA ? 'PSA is turned on' : 'PSA is turned off';
+      break;
     case 'stop':
-    description = descriptionInfo ? descriptionInfo : 'Turned off PSA!';
+      description = descriptionInfo ? descriptionInfo : 'Turned off PSA!';
+      break;
+    case 'start':
+      description = descriptionInfo ? descriptionInfo : 'Turned on PSA!';
+      break;
   }
   const embed = {
     description,
@@ -69,7 +90,7 @@ const generateEmbed = (type, descriptionInfo, updatedInfo) => {
       },
       {
         name: 'PSA Message',
-        value: PSAmessage
+        value: updatedInfo && updatedInfo.PSAmessage ? updatedInfo.PSAmessage : PSAmessage
       }
     ]
   }
@@ -81,7 +102,7 @@ module.exports = {
   devOnly: true,
   async execute(message) {
     if (message.author.id === '183444648360935424') {
-      return showPSA(message);
+      return startPSA(message, 'Lets gooo');
       // return setPSA(message, 'Hello', true);
     }
     return;

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -41,7 +41,7 @@ const showPSA = (message) => {
 const generateEmbed = (type, descriptionInfo, updatedInfo) => {
   let description;
   const PSAtext = PSA ? 'On' : 'Off';
-  const updatedPSAtext = updatedInfo.PSA ? 'On' : 'Off';
+  const updatedPSAtext = updatedInfo && updatedInfo.PSA ? 'On' : 'Off';
 
   switch(type){
     case 'show':
@@ -72,7 +72,7 @@ module.exports = {
   devOnly: true,
   async execute(message) {
     if (message.author.id === '183444648360935424') {
-      return stopPSA(message);
+      return showPSA(message);
       // return setPSA(message, 'Hello', true);
     }
     return;

--- a/commands/developer/psa.js
+++ b/commands/developer/psa.js
@@ -1,36 +1,63 @@
 const { PSA, PSAmessage } = require('../../config/psa.json');
+const fs = require('fs');
 
-const setPSA = (message, messageInfo, show) => {
-  if(show){
-    const showMessage = PSA ? 'PSA is turned on' : 'PSA is turned off'
-    
-  }
+const defaultMessage = "Oopsie!"
+
+const startPSA = (message, messageInfo) => {
   let psa;
-  //Toggles PSA
-  if(PSA){
-    psa = false;
-  } else {
-    psa = true;
-  }
   //Checks what message to show to user
   // if()
 }
 
+const stopPSA = (message) => {
+  if(!PSA){
+    return message.channel.send('PSA is already turned off');
+  }
+  const updatedPSAInfo = {
+    PSA: false,
+    PSAmessage: defaultMessage
+  }
+  fs.writeFile('./config/psa.json', JSON.stringify(updatedPSAInfo, null, 2), function (err) {
+    if (err) {
+      return console.log(err);
+    }
+    return message.channel.send('Turned off PSA');
+  });
+}
 /**
  * Shows if PSA is activated
- */
+ **/
 const showPSA = (message) => {
   const showMessage = PSA ? 'PSA is turned on' : 'PSA is turned off';
   return message.channel.send(showMessage);
 }
 
+// const generateEmbed = (type) => {
+//   if(type){
+
+//   }
+//   const embed = {
+//     color: 32896,
+//     fields: [
+//       {
+//         name: 'PSA',
+//         value: PSA ? 'on' : 'off'
+//       },
+//       {
+//         name: 'PSA Message',
+//         value: PSAmessage
+//       }
+//     ]
+//   }
+//   return embed;
+// }
 module.exports = {
   name: "psa",
   description: "Toggles a trigger that sends a public service announcement when using the timer. Only to be used in extreme cases where timer data is experiencing problems",
   devOnly: true,
   async execute(message) {
     if (message.author.id === '183444648360935424') {
-      return showPSA(message);
+      return stopPSA(message);
       // return setPSA(message, 'Hello', true);
     }
     return;

--- a/commands/timer/goats.js
+++ b/commands/timer/goats.js
@@ -2,6 +2,7 @@ const { api } = require('../../config/yagi.json');
 const { google } = require('googleapis');
 const sheets = google.sheets('v4');
 const { getServerTime, formatCountdown, formatLocation } = require('../../helpers');
+const { PSA, PSAmessage } = require('../../config/psa.json');
 const {
   format,
   differenceInMilliseconds,
@@ -208,7 +209,11 @@ module.exports = {
     //Since it'll take a couple of seconds to finish the request, adding bot type to show in-progress
     message.channel.startTyping();
     try {
-      await getWorldBossData(message, sendMessage);
+      if(PSA){
+        message.channel.send(PSAmessage);
+      }else {
+        getWorldBossData(message, sendMessage);
+      }
     } catch (e) {
       console.log(e);
       message.channel.send(e.message);

--- a/config/psa.json
+++ b/config/psa.json
@@ -1,4 +1,4 @@
 {
-  "PSA": true,
-  "PSAmessage": "Looks to be an error"
+  "PSA": false,
+  "PSAmessage": "Oopsie!"
 }

--- a/config/psa.json
+++ b/config/psa.json
@@ -1,4 +1,4 @@
 {
-  "PSA": false,
+  "PSA": true,
   "PSAmessage": "Oopsie!"
 }

--- a/config/psa.json
+++ b/config/psa.json
@@ -1,4 +1,0 @@
-{
-  "PSA": true,
-  "PSAmessage": "I'm an error message"
-}

--- a/config/psa.json
+++ b/config/psa.json
@@ -1,4 +1,4 @@
 {
-  "PSA": false,
-  "message": "Looks to be an error"
+  "PSA": true,
+  "PSAmessage": "Looks to be an error"
 }

--- a/config/psa.json
+++ b/config/psa.json
@@ -1,0 +1,4 @@
+{
+  "PSA": false,
+  "message": "Looks to be an error"
+}

--- a/config/psa.json
+++ b/config/psa.json
@@ -1,4 +1,4 @@
 {
   "PSA": true,
-  "PSAmessage": "Lets gooo"
+  "PSAmessage": "I'm an error message"
 }

--- a/config/psa.json
+++ b/config/psa.json
@@ -1,4 +1,4 @@
 {
   "PSA": true,
-  "PSAmessage": "Oopsie!"
+  "PSAmessage": "Lets gooo"
 }


### PR DESCRIPTION
#### Context
There was a huge lag wave a week ago that happened in the server. A lot of maintenance, a lot of disruption to the data. As yagi relies solely on the sheets, the timer was basically non-existent as leads were having some troubles in keeping track of the hunt. As the project in making yagi automated is still in its infancy and this kind of things happen from time to time, I'll be adding this feature to temporarily shut down the timer and send a message to the user that there are issues. 

Note: PSA = Public Service Announcement; this feature is more just for integrity and not wanting to spread wrong/faulty information. A dev command, only to be used by me

How it works:
- `psa show`; displays the information of the PSA
![image](https://user-images.githubusercontent.com/42207245/110507338-e1202a80-813a-11eb-8410-b04d36a9186a.png)
- `psa start {optional custom message}`; starts the PSA. Accepts a custom message but will use the default one if none is passed
![image](https://user-images.githubusercontent.com/42207245/110507635-25abc600-813b-11eb-8c9b-3e28fbc2cd64.png)
- `psa stop`; stops the PSA and reverts the psa message to the default one
![image](https://user-images.githubusercontent.com/42207245/110509145-c0f16b00-813c-11eb-8664-9fb34008cd6b.png)


#### Change
- Create psa command file
- Create psa json file
- Create show, start, stop and generate embed functions
- Add psa.json to gitignore
- Add condition to either show psa message or goat timer

#### Release Notes
Add PSA command for extreme cases where timer is experiencing data discrepancies