### PR TITLE
Deprecate custom prefix and message commands

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -13,8 +13,6 @@ module.exports = {
   // Reminder
   // ----------
   // Dev Tools
-  reply: require('./commands/developer/reply'),
-  message: require('./commands/developer/message'),
   daylights: require('./commands/developer/daylights'),
   offset: require('./commands/developer/offset'),
   psa: require('./commands/developer/psa'),

--- a/commands/developer/message.js
+++ b/commands/developer/message.js
@@ -1,4 +1,4 @@
-const guildConfig = require('../../config/guild.json');
+// const guildConfig = require('../../config/guild.json');
 const { defaultPrefix } = require('../../config/yagi.json');
 const grvAcnt = '`';
 const { format } = require('date-fns');

--- a/commands/developer/message.js
+++ b/commands/developer/message.js
@@ -1,4 +1,10 @@
-// const guildConfig = require('../../config/guild.json');
+/**
+ * DEPRECATED 
+ * Was a good idea but user adoption has been minimal
+ * Its infancy stemmed from trying to reinvent the wheel when I could have just invited users to a dedicated discord server for interactions
+ * Keeping this file to serve as a reminder of past mistakes and inspiration since despite all, it was fun creating this feature
+ */
+const guildConfig = require('../../config/guild.json');
 const { defaultPrefix } = require('../../config/yagi.json');
 const grvAcnt = '`';
 const { format } = require('date-fns');

--- a/commands/developer/reply.js
+++ b/commands/developer/reply.js
@@ -1,3 +1,9 @@
+/**
+ * DEPRECATED 
+ * Was a good idea but user adoption has been minimal
+ * Its infancy stemmed from trying to reinvent the wheel when I could have just invited users to a dedicated discord server for interactions
+ * Keeping this file to serve as a reminder of past mistakes and inspiration since despite all, it was fun creating this feature
+ */
 const { format } = require('date-fns');
 const sendSuccessEmbed = function designOfSuccessNotificationEmbed(message, replyContent) {
   const embed = {

--- a/commands/hub/help.js
+++ b/commands/hub/help.js
@@ -25,7 +25,7 @@ module.exports = {
           {
             name: 'Miscellaneous',
             value:
-              '`loot`, `contacts`, `message`, `website`\n\nFor more detailed information about a command, use `' +
+              '`loot`, `contacts`, `website`\n\nFor more detailed information about a command, use `' +
               yagiPrefix +
               'help <Command>`'
           }

--- a/commands/hub/info.js
+++ b/commands/hub/info.js
@@ -5,7 +5,7 @@ const grvAcnt = '`';
 const sendInfoEmbed = function designOfYagiInformationEmbed(message, yagi, yagiPrefix) {
   const embed = {
     title: 'Info',
-    description: `Hi there! I'm Yagi and I provide information for the world bosses of Vulture's Vale and Blizzard Berg in Aura Kingdom EN!\n\nInitially my creator only wanted to make a [website](https://ak-goats.com/) but eventually opted to make a discord version as well! Since then I'm currently serving ${yagi.guilds.size} servers!\n\nMy timer data is extracted from the player-run [Olympus WB Sheet](https://docs.google.com/spreadsheets/d/tUL0-Nn3Jx7e6uX3k4_yifQ/edit#gid=585652389). Kudos to the hardwork of the editors and leads in the team!\n\nMy prefix  is ${grvAcnt}${yagiPrefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${yagiPrefix}help${grvAcnt}`, //Removed users for now
+    description: `Hi there! I'm Yagi and I provide information for the world bosses of Vulture's Vale and Blizzard Berg in Aura Kingdom EN!\n\nInitially my creator only wanted to make a [website](https://ak-goats.com/) but eventually opted to make a discord version as well! Since then I'm currently serving ${yagi.guilds.cache.size} servers!\n\nMy timer data is extracted from the player-run [Olympus WB Sheet](https://docs.google.com/spreadsheets/d/tUL0-Nn3Jx7e6uX3k4_yifQ/edit#gid=585652389). Kudos to the hardwork of the editors and leads in the team!\n\nMy prefix  is ${grvAcnt}${yagiPrefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${yagiPrefix}help${grvAcnt}`, //Removed users for now
     color: 32896,
     thumbnail: {
       url:

--- a/commands/misc/contacts.js
+++ b/commands/misc/contacts.js
@@ -1,10 +1,11 @@
-// const guildConfig = require('../../config/guild.json');
+//Reminder comment to add Yagi discord server in contacts before v2.5
+const { defaultPrefix } = require('../../config/yagi.json');
 
 module.exports = {
   name: 'contacts',
   description: 'Shows platforms in which you can contact the owner',
   execute(message) {
-    const currentPrefix = guildConfig[message.guild.id].prefix;
+    const currentPrefix = defaultPrefix;
     const embed = {
       description:
         'If you have any feedback or just want to hit me up, you can reach me through any of the platforms listed below!',

--- a/commands/misc/contacts.js
+++ b/commands/misc/contacts.js
@@ -1,4 +1,4 @@
-const guildConfig = require('../../config/guild.json');
+// const guildConfig = require('../../config/guild.json');
 
 module.exports = {
   name: 'contacts',

--- a/commands/misc/prefix.js
+++ b/commands/misc/prefix.js
@@ -1,4 +1,4 @@
-const guildConfig = require('../../config/guild.json');
+// const guildConfig = require('../../config/guild.json');
 const fs = require('fs');
 const grvAcnt = '`';
 

--- a/commands/misc/prefix.js
+++ b/commands/misc/prefix.js
@@ -1,13 +1,9 @@
-// const guildConfig = require('../../config/guild.json');
-const fs = require('fs');
-const grvAcnt = '`';
+//Reminder to add custom prefix before v3
+const { defaultPrefix } = require('../../config/yagi.json');
 
 const generateEmbed = function designOfPrefixEmbed(currentPrefix) {
   const embed = {
     color: 32896,
-    footer: {
-      text: 'Only members with the administrator role can change my prefix'
-    },
     fields: [
       {
         name: 'Current Prefix',
@@ -18,10 +14,6 @@ const generateEmbed = function designOfPrefixEmbed(currentPrefix) {
         name: 'Usage Example',
         value: `${currentPrefix}help`,
         inline: true
-      },
-      {
-        name: 'How to change prefix',
-        value: `• This command accepts one argument\n• ${grvAcnt}${currentPrefix} prefix {Argument}${grvAcnt}\n• Argument: ${grvAcnt}"Your custom prefix"${grvAcnt}\n• Wrapping your prefix between double quotes is compulsory\n• Example prefix w/o space: ${grvAcnt}${currentPrefix} prefix "$"${grvAcnt} will then be ${grvAcnt}$help${grvAcnt}\n• Example prefix w/ space: ${grvAcnt}${currentPrefix} prefix "$ "${grvAcnt} will then be ${grvAcnt}$ help${grvAcnt}`
       }
     ]
   };
@@ -30,51 +22,11 @@ const generateEmbed = function designOfPrefixEmbed(currentPrefix) {
 
 module.exports = {
   name: 'prefix',
-  description:
-    'Shows current prefix. Can also accept one argument to customize the prefix. This argument should be wrapped within `""` and cannot be empty. Only admins have the ability to change prefixes',
-  hasArguments: true,
-  exampleArgument: '$',
-  execute(message, arguments) {
-    if(message){
-      return message.channel.send(`Sorry there's something wrong with this command for now (◕︿◕✿) Currently working on a fix, will get it up and running next patch!`)
-    }
-    const currentPrefix = guildConfig[message.guild.id].prefix;
-    /**
-     * First logic sends default prefix embed
-     * Second sends error if argument supplied is an empty prefix
-     * Third sends an error if you're not an admin
-     * Fourth does the actual updating of prefix
-     * Last just tells the user to wrap argument between double qoutes
-     */
-    if (arguments.length === 0) {
-      const embed = generateEmbed(currentPrefix);
-      message.channel.send({ embed });
-    } else if (arguments.length <= 2) {
-      message.channel.send(`You can't use an empty prefix（・□・；)`);
-    } else if (!message.member.hasPermission('ADMINISTRATOR')) {
-      message.channel.send('Sorry, only admins can use this command :c');
-    } else if (
-      arguments.startsWith('"') &&
-      arguments.endsWith('"') &&
-      arguments.length > 2 &&
-      message.member.hasPermission('ADMINISTRATOR')
-    ) {
-      const newPrefix = arguments.replace(/"/g, '');
-      if (newPrefix === currentPrefix) {
-        message.channel.send(`Can't update to the same prefix（・□・；)`);
-      } else {
-        guildConfig[message.guild.id].prefix = newPrefix;
-        fs.writeFile('./config/guild.json', JSON.stringify(guildConfig, null, 2), function(err) {
-          if (err) {
-            return console.log(err);
-          }
-          message.channel.send(
-            `Update successful!\n• New prefix: ${grvAcnt}${newPrefix}${grvAcnt}\n• Example Usage: ${grvAcnt}${newPrefix}help${grvAcnt}`
-          );
-        });
-      }
-    } else {
-      message.channel.send('Please wrap your custom prefix between `""`');
-    }
+  description: 'Shows current prefix',
+  hasArguments: false,
+  execute(message) {
+    const currentPrefix = defaultPrefix;
+    const embed = generateEmbed(currentPrefix);
+    message.channel.send({ embed });
   }
 };

--- a/yagi.js
+++ b/yagi.js
@@ -74,7 +74,7 @@ yagi.on('message', async (message) => {
     message.mentions.users.forEach((user) => {
       //shows current prefix when @
       if (user === yagi.user) {
-        return message.channel.send('My current prefix is ' + '`' + `${yagiPrefix}` + '`');
+        return message.channel.send('My current prefix is ' + '`' + `${yagiPrefix}` + '`' + '. For list of commands, type '+ '`' + `${yagiPrefix}help` + '`');
       }
     });
     //Ignores messages without a prefix

--- a/yagi.js
+++ b/yagi.js
@@ -2,7 +2,6 @@ const Discord = require('discord.js');
 const { defaultPrefix, token } = require('./config/yagi.json');
 const commands = require('./commands');
 const yagi = new Discord.Client();
-const guildConfig = require('./config/guild.json');
 const sqlite = require('sqlite3').verbose();
 const { serverEmbed } = require('./helpers');
 const { createGuildTable, insertNewGuild, deleteGuild } = require('./database/guild-db.js');
@@ -65,21 +64,20 @@ yagi.on('guildDelete', (guild) => {
 yagi.on('message', async (message) => {
   if (message.author.bot) return; //Ignore messages made my yagi
   const logChannel = yagi.channels.cache.get('620621811142492172');
-  let yagiPrefix;
-  if (message.channel.type === 'dm' || message.channel.type === 'group') {
-    yagiPrefix = defaultPrefix;
-  } else if (message.channel.type === 'text') {
-    yagiPrefix = guildConfig[message.guild.id].prefix;
-  }
-  //Ignores messages without a prefix
+  const yagiPrefix = defaultPrefix; //Keeping this way for now to remind myself to add a better way for custom prefixes
+
   try {
+    /**
+     * Yagi checks if messages contains any mentions
+     * If it does and if one of the mentions contains yagi's user, returns a message with the current prefix
+     */
     message.mentions.users.forEach((user) => {
       //shows current prefix when @
       if (user === yagi.user) {
         return message.channel.send('My current prefix is ' + '`' + `${yagiPrefix}` + '`');
       }
     });
-
+    //Ignores messages without a prefix
     if (message.content.startsWith(yagiPrefix)) {
       const args = message.content.slice(yagiPrefix.length).split(' ', 1); //takes off prefix and returns first word as an array
       const command = args.shift().toLowerCase(); //gets command as a string from array


### PR DESCRIPTION
#### Context
With the addition of a dedicated guild database, reliant on the guild.json file for custom prefixes will cause breaking changes. As there were issues previously with that function, I went ahead and deprecated that whole feature and will revisit when I have bandwidth. Since I'm in a deprecating mood, removed the `message` and `reply` commands too as both didn't have much user adoption. It's a far better idea to just invite users to an actual discord server to collect feedback anyway lol I'll have to setup that before the next release

#### Change
- Deprecate message command
- Deprecate reply command
- Deprecate custom prefix function
- Update contacts, help, info and prefix commands

#### Release Notes
Deprecate custom prefix and message commands