### PR TITLE
Add mixpanel events

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,52 @@
+/**
+ * User and event tracking for Yagi using Mixpanel
+ * The one thing I struggled with post-launch in projects was getting feedback from users on how to better improve my apps
+ * For the most part, I've just been asking around friends and friends of friends about them and as insightful it may be, it's still a hassle and manual to do
+ * With automating tracking, I get a first-hand source of truth of user adoption
+ * I do regret not implementing this right in the begininng but better late than never? It's been one hell of a learning experience anyway and I doubt I'll forget to add these in new projects
+ * For reference: https://developer.mixpanel.com/docs/nodejs
+ */
+ const sendMixpanelEvent = (user, channel, guild, command, client) => {
+  const eventToSend = `Use ${command} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
+  /**
+   * Event to send to mixpanel
+   * Added relevant properties along with event such as user, channel and guild
+   * Important to always send `distinct_id` as mixpanel-nodejs uses this as its unique identifier
+   */
+  client.track(eventToSend, {
+    distinct_id: user.id,
+    user: user.tag,
+    user_name: user.username,
+    channel: channel.name,
+    channel_id: channel.id,
+    guild: guild.name,
+    guild_id: guild.id,
+    command: command
+  })
+  /**
+   * Creates and updates a user profile
+   * Sets properties everytime event is called and overrides if they're different
+   */
+  client.people.set(user.id, {
+    $name: user.username,
+    $created: user.createdAt.toISOString(),
+    tag: user.tag,
+    guild: guild.name,
+    guild_id: guild.id
+  })
+  /**
+   * Sets a user profile properties only once
+   * Gets called on every event but doesn't override property if it already exists
+   * Useful for first time stuff
+   */
+  client.people.set_once(user.id, {
+    first_used: (new Date()).toISOString(), //Unfortunately this is only after v2.5
+    first_command: command,
+    first_used_in_guild: guild.name,
+    first_used_in_channel: channel.name
+  })
+}
+
+module.exports = {
+  sendMixpanelEvent
+}

--- a/yagi.js
+++ b/yagi.js
@@ -224,4 +224,10 @@ const sendMixpanelEvent = (user, channel, guild, command, client) => {
     guild: guild.name,
     guild_id: guild.id
   })
+  client.people.set_once(user.id, {
+    first_used: (new Date()).toISOString(), //Unfortunately this is only after v2.5
+    first_command: command,
+    first_used_in_guild: guild.name,
+    first_used_in_channel: channel.name
+  })
 }

--- a/yagi.js
+++ b/yagi.js
@@ -51,7 +51,7 @@ yagi.once('ready', () => {
      * Initialise Database and its tables
      * Will create them if they don't exist
      * See relevant files under database/* for more information
-     */
+     */ 
     const yagiDatabase = createYagiDatabase();
     createGuildTable(yagiDatabase, yagi.guilds.cache, yagi);
     createChannelTable(yagiDatabase, yagi.channels.cache, yagi);
@@ -201,13 +201,20 @@ const createYagiDatabase = () => {
   return db;
 }
 /**
- * Aparently the node js mixpanel library does not support identify and super properties as inherently it's not client-side and doesn't concern itself with what the user does
- * This doesn't go too well with my use case of wanting to track user interaction with the app
- * Fortunately there's a workaround but would require passing the properties for each event
- * Will implement in a new pr
+ * User and event tracking for Yagi using Mixpanel
+ * The one thing I struggled with post-launch in projects was getting feedback from users on how to better improve my apps
+ * For the most part, I've just been asking around friends and friends of friends about them and as insightful it may be, it's still a hassle and manual to do
+ * With automating tracking, I get a first-hand source of truth of user adoption
+ * I do regret not implementing this right in the begininng but better late than never? It's been one hell of a learning experience anyway and I doubt I'll forget to add these in new projects
+ * For reference: https://developer.mixpanel.com/docs/nodejs
  */
 const sendMixpanelEvent = (user, channel, guild, command, client) => {
-  const eventToSend = `Use ${command} command`;
+  const eventToSend = `Use ${command} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
+  /**
+   * Event to send to mixpanel
+   * Added relevant properties along with event such as user, channel and guild
+   * Important to always send `distinct_id` as mixpanel-nodejs uses this as its unique identifier
+   */
   client.track(eventToSend, {
     distinct_id: user.id,
     user: user.tag,
@@ -215,8 +222,13 @@ const sendMixpanelEvent = (user, channel, guild, command, client) => {
     channel: channel.name,
     channel_id: channel.id,
     guild: guild.name,
-    guild_id: guild.id
+    guild_id: guild.id,
+    command: command
   })
+  /**
+   * Creates and updates a user profile
+   * Sets properties everytime event is called and overrides if they're different
+   */
   client.people.set(user.id, {
     $name: user.username,
     $created: user.createdAt.toISOString(),
@@ -224,6 +236,11 @@ const sendMixpanelEvent = (user, channel, guild, command, client) => {
     guild: guild.name,
     guild_id: guild.id
   })
+  /**
+   * Sets a user profile properties only once
+   * Gets called on every event but doesn't override property if it already exists
+   * Useful for first time stuff
+   */
   client.people.set_once(user.id, {
     first_used: (new Date()).toISOString(), //Unfortunately this is only after v2.5
     first_command: command,

--- a/yagi.js
+++ b/yagi.js
@@ -217,7 +217,11 @@ const sendMixpanelEvent = (user, channel, guild, command, client) => {
     guild: guild.name,
     guild_id: guild.id
   })
-  console.log(user);
-  console.log(user.createdAt);
-  console.log(user.createdAt.toISOString());
+  client.people.set(user.id, {
+    $name: user.username,
+    $created: user.createdAt.toISOString(),
+    tag: user.tag,
+    guild: guild.name,
+    guild_id: guild.id
+  })
 }

--- a/yagi.js
+++ b/yagi.js
@@ -179,6 +179,7 @@ yagi.on('message', async (message) => {
           await message.channel.send("That command doesn't accept arguments （・□・；）");
         } else {
           await commands[command].execute(message, arguments, yagi, commands, yagiPrefix);
+          sendMixpanelEvent(message.author, message.channel, message.channel.guild, command, mixpanel);
         }
       } else {
         await message.channel.send("I'm not sure what you meant by that! （・□・；）");
@@ -205,10 +206,10 @@ const createYagiDatabase = () => {
  * Fortunately there's a workaround but would require passing the properties for each event
  * Will implement in a new pr
  */
-const setMixpanelUser = (user, channel, guild, client) => {
-  client.identify(user.id);
-  client.register({
-    user_id: user.id,
+const sendMixpanelEvent = (user, channel, guild, command, client) => {
+  const eventToSend = `Use ${command} command`;
+  client.track(eventToSend, {
+    distinct_id: user.id,
     user: user.tag,
     user_name: user.username,
     channel: channel.name,
@@ -216,4 +217,7 @@ const setMixpanelUser = (user, channel, guild, client) => {
     guild: guild.name,
     guild_id: guild.id
   })
+  console.log(user);
+  console.log(user.createdAt);
+  console.log(user.createdAt.toISOString());
 }

--- a/yagi.js
+++ b/yagi.js
@@ -7,6 +7,7 @@ const Mixpanel = require('mixpanel');
 const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment } = require('./helpers');
 const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildMemberCount } = require('./database/guild-db.js');
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
+const { sendMixpanelEvent } = require('./analytics');
 
 const activitylist = [
   'info | bot information',
@@ -27,6 +28,7 @@ const initialize = async () => {
   mixpanel = Mixpanel.init(checkIfInDevelopment(yagi) ? bisoMixpanel : yagiMixpanel);
 }
 initialize();
+
 /**
  * Event handler that fires only once when yagi is done booting up
  * Houses function initialisations such as database creation and activity list randomizer
@@ -179,7 +181,7 @@ yagi.on('message', async (message) => {
           await message.channel.send("That command doesn't accept arguments （・□・；）");
         } else {
           await commands[command].execute(message, arguments, yagi, commands, yagiPrefix);
-          sendMixpanelEvent(message.author, message.channel, message.channel.guild, command, mixpanel);
+          sendMixpanelEvent(message.author, message.channel, message.channel.guild, command, mixpanel); //Send tracking event to mixpanel
         }
       } else {
         await message.channel.send("I'm not sure what you meant by that! （・□・；）");
@@ -199,52 +201,4 @@ yagi.on('error', (error) => {
 const createYagiDatabase = () => {
   let db = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE | sqlite.OPEN_CREATE);
   return db;
-}
-/**
- * User and event tracking for Yagi using Mixpanel
- * The one thing I struggled with post-launch in projects was getting feedback from users on how to better improve my apps
- * For the most part, I've just been asking around friends and friends of friends about them and as insightful it may be, it's still a hassle and manual to do
- * With automating tracking, I get a first-hand source of truth of user adoption
- * I do regret not implementing this right in the begininng but better late than never? It's been one hell of a learning experience anyway and I doubt I'll forget to add these in new projects
- * For reference: https://developer.mixpanel.com/docs/nodejs
- */
-const sendMixpanelEvent = (user, channel, guild, command, client) => {
-  const eventToSend = `Use ${command} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
-  /**
-   * Event to send to mixpanel
-   * Added relevant properties along with event such as user, channel and guild
-   * Important to always send `distinct_id` as mixpanel-nodejs uses this as its unique identifier
-   */
-  client.track(eventToSend, {
-    distinct_id: user.id,
-    user: user.tag,
-    user_name: user.username,
-    channel: channel.name,
-    channel_id: channel.id,
-    guild: guild.name,
-    guild_id: guild.id,
-    command: command
-  })
-  /**
-   * Creates and updates a user profile
-   * Sets properties everytime event is called and overrides if they're different
-   */
-  client.people.set(user.id, {
-    $name: user.username,
-    $created: user.createdAt.toISOString(),
-    tag: user.tag,
-    guild: guild.name,
-    guild_id: guild.id
-  })
-  /**
-   * Sets a user profile properties only once
-   * Gets called on every event but doesn't override property if it already exists
-   * Useful for first time stuff
-   */
-  client.people.set_once(user.id, {
-    first_used: (new Date()).toISOString(), //Unfortunately this is only after v2.5
-    first_command: command,
-    first_used_in_guild: guild.name,
-    first_used_in_channel: channel.name
-  })
 }


### PR DESCRIPTION
#### Context
Sends events to track to Mixpanel with relevant properties such as user, channel and guild information for each event used. Also creates/updates user profiles and first time properties. Regret not being able to implement this at the start of the project as the insights would be hella beneficial in shaping the product map but better late than never. Will be more mindful about analytics in future projects

Dashboard Preview:
![image](https://user-images.githubusercontent.com/42207245/124374671-f4e63280-dccf-11eb-945c-559463d495a3.png)

#### Change
- Send events to mixpanel
- Send user profile data
- Send first time properties
- Add analytics file

#### Release Notes
Add mixpanel events