### PR TITLE
Remove command functionality from dms

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -9,42 +9,54 @@
  const sendMixpanelEvent = (user, channel, guild, command, client) => {
   const eventToSend = `Use ${command} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
   /**
-   * Event to send to mixpanel
-   * Added relevant properties along with event such as user, channel and guild
-   * Important to always send `distinct_id` as mixpanel-nodejs uses this as its unique identifier
-   */
-  client.track(eventToSend, {
-    distinct_id: user.id,
-    user: user.tag,
-    user_name: user.username,
-    channel: channel.name,
-    channel_id: channel.id,
-    guild: guild.name,
-    guild_id: guild.id,
-    command: command
-  })
-  /**
    * Creates and updates a user profile
    * Sets properties everytime event is called and overrides if they're different
    */
-  client.people.set(user.id, {
+   client.people.set(user.id, {
     $name: user.username,
     $created: user.createdAt.toISOString(),
     tag: user.tag,
     guild: guild.name,
     guild_id: guild.id
   })
-  /**
-   * Sets a user profile properties only once
-   * Gets called on every event but doesn't override property if it already exists
-   * Useful for first time stuff
-   */
-  client.people.set_once(user.id, {
-    first_used: (new Date()).toISOString(), //Unfortunately this is only after v2.5
-    first_command: command,
-    first_used_in_guild: guild.name,
-    first_used_in_channel: channel.name
-  })
+  if(channel.type !== 'dm'){
+    /**
+     * Event to send to mixpanel
+     * Added relevant properties along with event such as user, channel and guild
+     * Important to always send `distinct_id` as mixpanel-nodejs uses this as its unique identifier
+     */
+    client.track(eventToSend, {
+      distinct_id: user.id,
+      user: user.tag,
+      user_name: user.username,
+      channel: channel.name,
+      channel_id: channel.id,
+      guild: guild.name,
+      guild_id: guild.id,
+      command: command
+    })
+    /**
+     * Sets a user profile properties only once
+     * Gets called on every event but doesn't override property if it already exists
+     * Useful for first time stuff
+     */
+    client.people.set_once(user.id, {
+      first_used: (new Date()).toISOString(), //Unfortunately this is only after v2.5
+      first_command: command,
+      first_used_in_guild: guild.name,
+      first_used_in_channel: channel.name
+    })
+  } else {
+    /**
+     * Separate tracking for dms
+     * Currently this is just to see if people actually message yagi privately instead of through a channel
+     */
+    client.track('Use command in private message', {
+      distinct_id: user.id,
+      user: user.tag,
+      user_name: user.username
+    })
+  }
 }
 
 module.exports = {

--- a/yagi.js
+++ b/yagi.js
@@ -35,7 +35,6 @@ initialize();
  */
 yagi.once('ready', () => {
   try {
-    mixpanel.track('')
     const testChannel = yagi.channels.cache.get('582213795942891521');
     testChannel.send("I'm booting up! (◕ᴗ◕✿)"); //Sends to test bot channel in yagi's den
     console.log("I'm ready! (◕ᴗ◕✿)");
@@ -79,7 +78,9 @@ yagi.once('ready', () => {
  */
 yagi.on('channelCreate', (channel) => {
   try {
-    insertNewChannel(channel);
+    if(channel.type !== 'dm'){
+      insertNewChannel(channel);
+    }
   } catch(e){
     sendErrorLog(yagi, e);
   }
@@ -153,6 +154,16 @@ yagi.on('guildMemberRemove', (member) => {
  */
 yagi.on('message', async (message) => {
   if (message.author.bot) return; //Ignore messages made by yagi
+  //Let users know that they can only use this in channels; sends sent_from_dm data to mixpanel to see if there's adoption for private messaging
+  if (message.channel.type === 'dm'){
+    const guildDM = {
+      id: 'sent_from_dm',
+      name: 'Sent From DM'
+    }
+    message.channel.send('My bad! I only work in server channels ( ≧Д≦)');
+    sendMixpanelEvent(message.author, message.channel, guildDM, '', mixpanel);
+  }
+
   const yagiPrefix = defaultPrefix; //Keeping this way for now to remind myself to add a better way for custom prefixes
 
   try {


### PR DESCRIPTION
#### Context
Remove dm functionalities when private messaging the bot. This is so that I'll only have to support channels when reminders are out and not specific users. I'm not entirely out of the idea of reinstating this so I added a tracker for when someone dm's yagi to see if there's user interest for it. 
![image](https://user-images.githubusercontent.com/42207245/124376342-2c0d1180-dcd9-11eb-9b14-2891dac8bb5b.png)
![image](https://user-images.githubusercontent.com/42207245/124376375-53fc7500-dcd9-11eb-88f6-11ffc76cadb8.png)


#### Change
- Remove dm functionalities
- Send dm event to mixpanel

#### Release Notes
Remove dm functionalities