### PR TITLE
Add footer if timer data is inaccurate

### DIFF
--- a/commands/timer/goats.js
+++ b/commands/timer/goats.js
@@ -114,28 +114,32 @@ const validateSpawn = function validateSpawnTimeUsingServerAndSpawnTime(worldBos
      */
     return {
       nextSpawn: format(addHours(subDays(nextSpawnDate, 1), 4), 'h:mm:ss A'),
-      countdown: formatCountdown(addHours(subDays(nextSpawnDate, 1), 4), serverTime)
+      countdown: formatCountdown(addHours(subDays(nextSpawnDate, 1), 4), serverTime),
+      accurate: true
     };
   } else if (countdownValidity >= 0) {
     //normal timer (12am - 7:59pm server time) with updated sheet
     //Countdown still counting down
     return {
       nextSpawn: worldBossData.nextSpawn,
-      countdown: formatCountdown(nextSpawnDate, serverTime)
+      countdown: formatCountdown(nextSpawnDate, serverTime),
+      accurate: false
     };
   } else if (isAfter(serverTime, eightPMCutOff) && nextSpawnDate.includes('AM')) {
     //late night timer; servertime is over 8pm and sheet is updated
     //+1 day to current nextSpawnDate
     return {
       nextSpawn: worldBossData.nextSpawn,
-      countdown: formatCountdown(addDays(nextSpawnDate, 1), serverTime)
+      countdown: formatCountdown(addDays(nextSpawnDate, 1), serverTime),
+      accurate: true
     };
   } else if (countdownValidity < 0) {
     //Edge case - no editor updated sheet for both normal and late night flow
     //+4 hours to current nextSpawnDate
     return {
       nextSpawn: format(addHours(nextSpawnDate, 4), 'h:mm:ss A'),
-      countdown: formatCountdown(addHours(nextSpawnDate, 4), serverTime)
+      countdown: formatCountdown(addHours(nextSpawnDate, 4), serverTime),
+      accurate: false
     };
   }
 };

--- a/commands/timer/goats.js
+++ b/commands/timer/goats.js
@@ -176,6 +176,9 @@ const generateEmbed = function generateWorldBossEmbedToSend(worldBossData) {
       url:
         'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png'
     },
+    footer: {
+      text: `**Note that sheet data isn't up to date, timer might be a couple of minutes off`
+    },
     fields: [
       {
         name: 'Location',

--- a/commands/timer/goats.js
+++ b/commands/timer/goats.js
@@ -115,7 +115,7 @@ const validateSpawn = function validateSpawnTimeUsingServerAndSpawnTime(worldBos
     return {
       nextSpawn: format(addHours(subDays(nextSpawnDate, 1), 4), 'h:mm:ss A'),
       countdown: formatCountdown(addHours(subDays(nextSpawnDate, 1), 4), serverTime),
-      accurate: true
+      accurate: false
     };
   } else if (countdownValidity >= 0) {
     //normal timer (12am - 7:59pm server time) with updated sheet
@@ -123,7 +123,7 @@ const validateSpawn = function validateSpawnTimeUsingServerAndSpawnTime(worldBos
     return {
       nextSpawn: worldBossData.nextSpawn,
       countdown: formatCountdown(nextSpawnDate, serverTime),
-      accurate: false
+      accurate: true
     };
   } else if (isAfter(serverTime, eightPMCutOff) && nextSpawnDate.includes('AM')) {
     //late night timer; servertime is over 8pm and sheet is updated
@@ -160,6 +160,7 @@ const generateEmbed = function generateWorldBossEmbedToSend(worldBossData) {
   const spawnDesc = `Spawn: ${grvAcnt}${worldBossData.location.toLowerCase()}, ${
     validateSpawn(worldBossData, getServerTime()).nextSpawn
   }${grvAcnt}`;
+  const spawnFooter = validateSpawn(worldBossData, getServerTime()).accurate ? '' : `**Note that sheet data isn't up to date, timer might be a couple of minutes off`;
   /** 
    * This is far easier to get countdown but it isn't as reliable and accurate
    * I'll just leave it here for reference
@@ -177,7 +178,7 @@ const generateEmbed = function generateWorldBossEmbedToSend(worldBossData) {
         'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png'
     },
     footer: {
-      text: `**Note that sheet data isn't up to date, timer might be a couple of minutes off`
+      text: spawnFooter
     },
     fields: [
       {

--- a/config/offset.json
+++ b/config/offset.json
@@ -1,5 +1,5 @@
 {
-  "currentOffset": 5,
+  "currentOffset": 4,
   "start": "14 March 2021",
   "end": "7 Nov 2021",
   "dstOffset": 4,

--- a/database/guild-db.js
+++ b/database/guild-db.js
@@ -32,7 +32,7 @@ const createGuildTable = (database, guilds, client) => {
             if(err){
               console.log(err);
             }
-            sendGuildUpdateNotification(client, guild);
+            sendGuildUpdateNotification(client, guild, 'join');
           })
         }
       })

--- a/helpers.js
+++ b/helpers.js
@@ -139,11 +139,11 @@ const serverEmbed = function designOfEmbedForShowingYagiJoiningAndLeavingServer(
         value: guild.name,
         inline: true,
       },
-      // {
-      //   name: 'Owner',
-      //   value: guild.owner.user.tag,
-      //   inline: true,
-      // },
+      {
+        name: 'Owner',
+        value: guild.members.fetch(guild.ownerID).then(guildMember => guildMember.user.tag),
+        inline: true,
+      },
       {
         name: 'Members',
         value: guild.memberCount,

--- a/helpers.js
+++ b/helpers.js
@@ -110,7 +110,7 @@ const formatLocation = function formatRawLocationDataIntoFullMapAndChannel(rawLo
  * Server Embed for when bot joining and leaving a server
  * Add iconURL logic to always return a png extension
  */
-const serverEmbed = function designOfEmbedForShowingYagiJoiningAndLeavingServer(
+const serverEmbed = async function designOfEmbedForShowingYagiJoiningAndLeavingServer(
   yagi,
   guild,
   status
@@ -136,23 +136,22 @@ const serverEmbed = function designOfEmbedForShowingYagiJoiningAndLeavingServer(
     fields: [
       {
         name: 'Name',
-        value: guild.name,
-        inline: true,
+        value: guild.name
       },
       {
         name: 'Owner',
-        value: guild.members.fetch(guild.ownerID).then(guildMember => guildMember.user.tag),
-        inline: true,
+        value: await guild.members.fetch(guild.ownerID).then(guildMember => guildMember.user.tag),
+        inline: true
       },
       {
         name: 'Members',
         value: guild.memberCount,
-        inline: true,
+        inline: true
       },
       {
         name: 'Region',
         value: capitalize(guild.region),
-        inline: true,
+        inline: true
       },
     ],
   };
@@ -213,8 +212,8 @@ const capitalize = function formatsFirstCharacterOfStringToUpperCase(string) {
  * @param client - initialising discord client
  * @param guild  - guild data
  */
-const sendGuildUpdateNotification = (client, guild) => {
-  const embed = serverEmbed(client, guild, 'join');
+const sendGuildUpdateNotification = async (client, guild) => {
+  const embed = await serverEmbed(client, guild, 'join');
   const channelId = checkIfInDevelopment(client) ? '582213795942891521' : '614749682849021972';
   const channelToSend = client.channels.cache.get(channelId);
   

--- a/helpers.js
+++ b/helpers.js
@@ -212,8 +212,8 @@ const capitalize = function formatsFirstCharacterOfStringToUpperCase(string) {
  * @param client - initialising discord client
  * @param guild  - guild data
  */
-const sendGuildUpdateNotification = async (client, guild) => {
-  const embed = await serverEmbed(client, guild, 'join');
+const sendGuildUpdateNotification = async (client, guild, type) => {
+  const embed = await serverEmbed(client, guild, type);
   const channelId = checkIfInDevelopment(client) ? '582213795942891521' : '614749682849021972';
   const channelToSend = client.channels.cache.get(channelId);
   

--- a/yagi.js
+++ b/yagi.js
@@ -114,7 +114,7 @@ yagi.on('guildCreate', (guild) => {
     guild.channels.cache.forEach(channel => {
       insertNewChannel(channel);
     })
-    sendGuildUpdateNotification(yagi, guild);
+    sendGuildUpdateNotification(yagi, guild, 'join');
   } catch(e){
     sendErrorLog(yagi, e);
   }
@@ -123,7 +123,7 @@ yagi.on('guildDelete', (guild) => {
   try {
     deleteGuild(guild);
     deleteAllChannels(guild);
-    sendGuildUpdateNotification(yagi, guild);
+    sendGuildUpdateNotification(yagi, guild, 'leave');
   } catch(e){
     sendErrorLog(yagi, e);
   }

--- a/yagi.js
+++ b/yagi.js
@@ -45,8 +45,9 @@ yagi.once('ready', () => {
       console.log(user.username);
     });
     yagi.guilds.cache.forEach((guild) => {
-      console.log(`${guild.name} - ${guild.region} : ${guild.memberCount}`);
+      guild.members.fetch(guild.ownerID).then(guildMember => console.log(`${guild.name} - ${guild.region} : ${guild.memberCount} : ${guildMember.user.tag}`))
     });
+
     console.log(`Number of guilds: ${yagi.guilds.cache.size}`);
     /**
      * Initialise Database and its tables


### PR DESCRIPTION
#### Context
With the introduction of reminders, there are edge cases to consider when reminding users.

1. Letting the user know the timer isn't accurate due to sheet not updated
2. Letting the user know an error occured

This pr addresses the former by adding a note in the footer declaring that the timer might be off by a couple of minutes. Currently this would only be ever shown when someone uses the timer when hunting is currently in progress (leads only update spawn times after the full run) and on the off chance no one from the wb team updates the sheet (yagi's timer is designed to add 8 hours to previous spawn if this happens hence the inaccuracy). 

In whichever case, it still relies a human touch hence prone to human error. No bandwidth to tackle that scope but it's in the roadmap post v2.5

Also reinstated guild owner in the guild embed notification and fixed some bugs on it

![image](https://user-images.githubusercontent.com/42207245/124532314-df454a00-de42-11eb-9c29-1fa99fc0d693.png)

![image](https://user-images.githubusercontent.com/42207245/124532191-9a211800-de42-11eb-9be6-b9e632df16d5.png)

#### Change
- Return accurate property when validating spawn time
- Add owner tag to guild embed notifications
- Pass in type for guild embed notifications
- Add condition to show footer note if sheet is up to date

#### Release Notes
Add footer note in timer if timer is inaccurate due to sheet not being updated