### PR TITLE
Create Remind Command

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -11,6 +11,7 @@ module.exports = {
   // ----------
 
   // Reminder
+  remind: require('./commands/reminder/remind'),
   // ----------
   // Dev Tools
   daylights: require('./commands/developer/daylights'),

--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -1,5 +1,3 @@
-const { hasArguments } = require("../developer/psa")
-
 const reminderInstructions = () => {
   const embed ={
     "description": "Personal reminder to notify you when world boss is spawning soon.\nCan only be activated in one channel per server by an admin.\n\n",
@@ -31,7 +29,18 @@ module.exports = {
   description : 'Activates a reminder inside a channel that pings users when world boss is spawning soon',
   hasArguments: true,
   execute(message, arguments, yagi, commands, yagiPrefix){
-    const embed = reminderInstructions();
-    message.channel.send({ embed });
+    if(arguments){
+      switch (arguments) {
+        case 'enable':
+          return message.channel.send('Reminder enabled!');
+        case 'disable':
+          return message.channel.send('Reminder disabled!');
+        default:
+          return message.channel.send('Only accepts `enable` or `disable` as arguments');
+      }
+    } else {
+      const embed = reminderInstructions();
+      message.channel.send({ embed });
+    }
   }
 }

--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -1,0 +1,37 @@
+const { hasArguments } = require("../developer/psa")
+
+const reminderInstructions = () => {
+  const embed ={
+    "description": "Personal reminder to notify you when world boss is spawning soon.\nCan only be activated in one channel per server by an admin.\n\n",
+    "color": 32896,
+    thumbnail: {
+      url:
+        'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png'
+    },
+    "fields": [
+      {
+        "name": "How to enable:",
+        "value": "1. In the channel you want to get notifications from, type `$yagi-remind enable`. This will activate reminders on the current channel.\n2. When a channel is successfully activated, a special message is sent to the channel with details about the reminder."
+      },
+      {
+        "name": "How to use",
+        "value": "1. When a channel is activated, Yagi creates a new role in the server `@Goat Hunters`\n2. To get reminders, simply react on the special message with :goat: and you will automatically get the role. *Note that by removing the reaction you will lose the role*\n3. When world boss is spawning soon, Yagi will ping the role\n\n*To get the special message again, type `$yagi-remind`. You can also edit the role to customise its name/color*"
+      },
+      {
+        "name": "How to disable",
+        "value": "1. Type `$yagi-remind disable` in the channel where reminders was enabled. This will deactivate reminders on the current channel.\n2. When a channel is succesfully deactivated, the `@Goat Hunters` role will be deleted"
+      }
+    ]
+  }
+  return embed;
+}
+
+module.exports = {
+  name: 'remind',
+  description : 'Activates a reminder inside a channel that pings users when world boss is spawning soon',
+  hasArguments: true,
+  execute(message, arguments, yagi, commands, yagiPrefix){
+    const embed = reminderInstructions();
+    message.channel.send({ embed });
+  }
+}

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -1,0 +1,40 @@
+const sqlite = require('sqlite3').verbose();
+const { generateUUID } = require('../helpers');
+
+const createRoleTable = async (database, guilds, client) => {
+  database.serialize(() => {
+    database.run('CREATE TABLE IF NOT EXISTS Role(uuid TEXT NOT NULL PRIMARY KEY, role_id TEXT NOT NULL, name TEXT NOT NULL, created_at TEXT NOT NULL, member_count INTEGER NOT NULL, color TEXT NOT NULL, guild_id TEXT NOT NULL, used_for_reminder BOOLEAN, reminder_id TEXT)');
+    
+    guilds.forEach(guild => {
+      guild.roles.cache.forEach(async role => {
+        await guild.members.fetch();
+        database.get(`SELECT * FROM Role WHERE role_id = ${role.id} AND guild_id = ${guild.id}`, (error, row) => {
+          if(error){
+            console.log(error);
+          }
+          if(!row){
+            database.run('INSERT INTO Role (uuid, role_id, name, created_at, member_count, color, guild_id, used_for_reminder, reminder_id) VALUES ($uuid, $role_id, $name, $created_at, $member_count, $color, $guild_id, $used_for_reminder, $reminder_id)', {
+              $uuid: generateUUID(),
+              $role_id: role.id,
+              $name: role.name,
+              $created_at: role.createdAt,
+              $member_count: role.members.size,
+              $color: role.hexColor,
+              $guild_id: guild.id,
+              $used_for_reminder: false,
+              $reminder_id: null
+            }, err => {
+              if(error){
+                console.log(err);
+              }
+            })
+          }
+        })
+      })
+    })
+  })
+}
+
+module.exports = {
+  createRoleTable
+}

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -47,6 +47,10 @@ const createRoleTable = async (database, guilds, client) => {
     })
   })
 }
+/**
+ * Adds new role to Role Table
+ * @param role - newly role created
+ */
 const insertNewRole = (role) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.run('INSERT INTO Role (uuid, role_id, name, created_at, member_count, color, guild_id, used_for_reminder, reminder_id) VALUES ($uuid, $role_id, $name, $created_at, $member_count, $color, $guild_id, $used_for_reminder, $reminder_id)', {
@@ -60,16 +64,31 @@ const insertNewRole = (role) => {
     $used_for_reminder: false,
     $reminder_id: null
   }, err => {
-    console.log('inserted role');
     if(err){
       console.log(err);
     }
   })
 }
+/**
+ * Deletes crole from Role table
+ * @param role - role that has been deleted
+ */
 const deleteRole = (role) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.run(`DELETE FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, err => {
-    console.log('deleted role');
+    if(err){
+      console.log(err);
+    }
+  })
+}
+/**
+ * Updates data of existing role with new details in database
+ * Only setting name and color as these are the only parameters we're saving in our database that can be edited by a user
+ * @param role - new updated details of role 
+ */
+const updateRole = (role) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.run(`UPDATE Role SET name = "${role.name}", color = "${role.hexColor}" WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, err => {
     if(err){
       console.log(err);
     }
@@ -79,5 +98,6 @@ const deleteRole = (role) => {
 module.exports = {
   createRoleTable,
   insertNewRole,
-  deleteRole
+  deleteRole,
+  updateRole
 }

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -1,10 +1,23 @@
 const sqlite = require('sqlite3').verbose();
 const { generateUUID } = require('../helpers');
-
+/**
+ * Creates Role table inside the Yagi Database
+ * Gets called in the client.once("ready") hook
+ * @param database - yagi database
+ * @param guilds - guilds that yagi is in; using this as roles are nested inside the guild collection
+ * @param client - yagi client
+ */
 const createRoleTable = async (database, guilds, client) => {
+  //Wrapped in a serialize to ensure that each method is called in order which its initialised
   database.serialize(() => {
+    //Creates Role Table with the relevant columns if it does not exist
     database.run('CREATE TABLE IF NOT EXISTS Role(uuid TEXT NOT NULL PRIMARY KEY, role_id TEXT NOT NULL, name TEXT NOT NULL, created_at TEXT NOT NULL, member_count INTEGER NOT NULL, color TEXT NOT NULL, guild_id TEXT NOT NULL, used_for_reminder BOOLEAN, reminder_id TEXT)');
     
+    /**
+     * Populate Role Table with existing roles for every guild
+     * As role_id is only unique to the guild that it is in, there is a possiblity that one role from one guild would have the same id as another role in another guild
+     * With this risk, we can't make role_id as the primary key and instead create a randomized uuid 
+     **/ 
     guilds.forEach(guild => {
       guild.roles.cache.forEach(async role => {
         await guild.members.fetch();

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -47,7 +47,35 @@ const createRoleTable = async (database, guilds, client) => {
     })
   })
 }
+const insertNewRole = (role) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.run('INSERT INTO Role (uuid, role_id, name, created_at, member_count, color, guild_id, used_for_reminder, reminder_id) VALUES ($uuid, $role_id, $name, $created_at, $member_count, $color, $guild_id, $used_for_reminder, $reminder_id)', {
+    $uuid: generateUUID(),
+    $role_id: role.id,
+    $name: role.name,
+    $created_at: role.createdAt,
+    $member_count: role.members.size,
+    $color: role.hexColor,
+    $guild_id: guild.id,
+    $used_for_reminder: false,
+    $reminder_id: null
+  }, err => {
+    if(error){
+      console.log(err);
+    }
+  })
+}
+const deleteRole = (role) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.run(`DELETE FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, err => {
+    if(err){
+      console.log(err);
+    }
+  })
+}
 
 module.exports = {
-  createRoleTable
+  createRoleTable,
+  insertNewRole,
+  deleteRole
 }

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -56,11 +56,12 @@ const insertNewRole = (role) => {
     $created_at: role.createdAt,
     $member_count: role.members.size,
     $color: role.hexColor,
-    $guild_id: guild.id,
+    $guild_id: role.guild.id,
     $used_for_reminder: false,
     $reminder_id: null
   }, err => {
-    if(error){
+    console.log('inserted role');
+    if(err){
       console.log(err);
     }
   })
@@ -68,6 +69,7 @@ const insertNewRole = (role) => {
 const deleteRole = (role) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.run(`DELETE FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, err => {
+    console.log('deleted role');
     if(err){
       console.log(err);
     }

--- a/helpers.js
+++ b/helpers.js
@@ -240,9 +240,7 @@ const sendErrorLog = (client, error) => {
  * UUID randomize generator
  */
 const generateUUID = () => {
-  const uuid = uuidv4();
-  console.log(uuid);
-  return uuid;
+  return uuidv4();
 }
 //----------
 module.exports = {

--- a/helpers.js
+++ b/helpers.js
@@ -10,6 +10,7 @@ const {
   subHours,
   subMinutes,
 } = require('date-fns');
+const { v4: uuidv4 } = require('uuid');
 const { currentOffset } = require('./config/offset.json');
 const grvAcnt = '`';
 
@@ -235,6 +236,15 @@ const sendErrorLog = (client, error) => {
   logChannel.send(error.message);
 }
 //----------
+/**
+ * UUID randomize generator
+ */
+const generateUUID = () => {
+  const uuid = uuidv4();
+  console.log(uuid);
+  return uuid;
+}
+//----------
 module.exports = {
   getServerTime,
   formatCountdown,
@@ -244,5 +254,6 @@ module.exports = {
   capitalize,
   checkIfInDevelopment,
   sendGuildUpdateNotification,
-  sendErrorLog
+  sendErrorLog,
+  generateUUID
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "mocha": "^6.2.0",
     "node.js": "^0.0.0",
     "nodemon": "^2.0.7",
-    "sqlite3": "^5.0.2"
+    "sqlite3": "^5.0.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "auto": "^10.13.1"

--- a/yagi.js
+++ b/yagi.js
@@ -35,7 +35,6 @@ initialize();
  */
 yagi.once('ready', () => {
   try {
-    generateUUID();
     const testChannel = yagi.channels.cache.get('582213795942891521');
     testChannel.send("I'm booting up! (◕ᴗ◕✿)"); //Sends to test bot channel in yagi's den
     console.log("I'm ready! (◕ᴗ◕✿)");
@@ -46,8 +45,15 @@ yagi.once('ready', () => {
       console.log(user.username);
     });
     yagi.guilds.cache.forEach((guild) => {
-      guild.members.fetch(guild.ownerID).then(guildMember => console.log(`${guild.name} - ${guild.region} : ${guild.memberCount} : ${guildMember.user.tag}`))
+      guild.members.fetch(guild.ownerID).then(guildMember => console.log(`Guild: ${guild.name} - ${guild.region} : ${guild.memberCount} : ${guildMember.user.tag}`))
     });
+    yagi.guilds.cache.forEach(guild => {
+      guild.roles.cache.forEach(role => {
+        guild.members.fetch().then(members => {
+          console.log(`Role: ${role.name} : ${guild.name} : ${role.members.size}`);
+        }) 
+      })
+    })
 
     console.log(`Number of guilds: ${yagi.guilds.cache.size}`);
     /**

--- a/yagi.js
+++ b/yagi.js
@@ -161,7 +161,20 @@ yagi.on('guildMemberRemove', (member) => {
   }
 })
 //------
-
+yagi.on('roleCreate', (role) => {
+  try {
+    insertNewRole(role);
+  } catch (e){
+    sendErrorLog(yagi, e)
+  }
+})
+yagi.on('roleDelete', (role) => {
+  try {
+    deleteRole(role);
+  } catch (e){
+    sendErrorLog(yagi, e)
+  }
+})
 //------
 /**
  * Event handler for when a message is sent in a channel that yagi is in

--- a/yagi.js
+++ b/yagi.js
@@ -7,7 +7,7 @@ const Mixpanel = require('mixpanel');
 const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment } = require('./helpers');
 const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildMemberCount } = require('./database/guild-db.js');
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
-const { createRoleTable, insertNewRole, deleteRole } = require('./database/role-db.js');
+const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
 const { sendMixpanelEvent } = require('./analytics');
 
 const activitylist = [
@@ -164,14 +164,22 @@ yagi.on('guildMemberRemove', (member) => {
 yagi.on('roleCreate', (role) => {
   try {
     insertNewRole(role);
-  } catch (e){
+  } catch(e){
     sendErrorLog(yagi, e)
   }
 })
 yagi.on('roleDelete', (role) => {
   try {
     deleteRole(role);
-  } catch (e){
+  } catch(e){
+    sendErrorLog(yagi, e)
+  }
+})
+yagi.on('roleUpdate', (_, newRole) => {
+  try {
+    updateRole(newRole);
+  }
+  catch(e){
     sendErrorLog(yagi, e)
   }
 })

--- a/yagi.js
+++ b/yagi.js
@@ -4,7 +4,7 @@ const commands = require('./commands');
 const yagi = new Discord.Client();
 const sqlite = require('sqlite3').verbose();
 const Mixpanel = require('mixpanel');
-const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment } = require('./helpers');
+const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment, generateUUID } = require('./helpers');
 const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildMemberCount } = require('./database/guild-db.js');
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { sendMixpanelEvent } = require('./analytics');
@@ -35,6 +35,7 @@ initialize();
  */
 yagi.once('ready', () => {
   try {
+    generateUUID();
     const testChannel = yagi.channels.cache.get('582213795942891521');
     testChannel.send("I'm booting up! (◕ᴗ◕✿)"); //Sends to test bot channel in yagi's den
     console.log("I'm ready! (◕ᴗ◕✿)");

--- a/yagi.js
+++ b/yagi.js
@@ -7,7 +7,7 @@ const Mixpanel = require('mixpanel');
 const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment } = require('./helpers');
 const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildMemberCount } = require('./database/guild-db.js');
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
-const { createRoleTable } = require('./database/role-db.js');
+const { createRoleTable, insertNewRole, deleteRole } = require('./database/role-db.js');
 const { sendMixpanelEvent } = require('./analytics');
 
 const activitylist = [
@@ -160,7 +160,9 @@ yagi.on('guildMemberRemove', (member) => {
     sendErrorLog(yagi, e);
   }
 })
-//-----
+//------
+
+//------
 /**
  * Event handler for when a message is sent in a channel that yagi is in
  */

--- a/yagi.js
+++ b/yagi.js
@@ -161,6 +161,13 @@ yagi.on('guildMemberRemove', (member) => {
   }
 })
 //------
+/**
+ * Event handlers for when a role in a guild where yagi is in gets created, deleted and updated
+ * A bit overkill to store these since all that's needed is the roles that are used for reminders but might as well just store everything
+ * roleCreate - called when a role is created in a server
+ * roleDelete - called when a role is deleted in a server
+ * roleUpdate - called when updating details (e.g. name change, color change) in a server
+ */
 yagi.on('roleCreate', (role) => {
   try {
     insertNewRole(role);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3420,6 +3420,11 @@ uuid@^3.2.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"


### PR DESCRIPTION
#### Context
Not sure if I'm over-engineering this but I feel like the alternative of just using `@here` seems too menial. My current story for using reminders: 

1. Type $yagi-reminder enable
2. Show enabled embed
3. Add goat reaction to enabled embed
4. Yagi adds `@Goat Hunters` role to user
5. 10 minutes before wb, yagi pings `@Goat Hunters` at channel where it got enabled

That's the most straightforward use case I can think of. There's still a lot to consider, especially if I want to reduce clutter of channel by deleting past reminders(?) and how to deal with server maintenances. Probably shouldn't delve too much in onboarding, gotta figure out a stable way in actually reminding that depends on a changing date.

Also created database statements for creation, updating and deleting of roles. Might be overkill to store these but felt that it's more straightforward to keep them along with the hunter roles than having to filter for specific ones.

![image](https://user-images.githubusercontent.com/42207245/124919618-05c4da00-e029-11eb-9af1-d30a5166741c.png)
![image](https://user-images.githubusercontent.com/42207245/124919897-52a8b080-e029-11eb-8d9f-3601d4ca4461.png)
![image](https://user-images.githubusercontent.com/42207245/124921355-e333c080-e02a-11eb-9cf9-db65e48fca92.png)

#### Change
- Install uuid
- Create uuid generator function
- Create role db file
- Create insert, delete and update statements for role
- Create remind command and information embed
- Add argument conditions for enable and disable


#### Release Notes
Create Remind Command
Create Role Table and relevant function statements