### PR TITLE
Create Reminder table in database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 
 #database
 /database/yagi.db
+/database/yagi.db-journal
 
 # system files
 .DS_Store

--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -1,3 +1,5 @@
+const { insertNewReminder } = require('../../database/reminder-db');
+
 const reminderInstructions = () => {
   const embed ={
     "description": "Personal reminder to notify you when world boss is spawning soon.\nCan only be activated in one channel per server by an admin.\n\n",
@@ -29,9 +31,11 @@ module.exports = {
   description : 'Activates a reminder inside a channel that pings users when world boss is spawning soon',
   hasArguments: true,
   execute(message, arguments, yagi, commands, yagiPrefix){
+    console.log(message);
     if(arguments){
       switch (arguments) {
         case 'enable':
+          insertNewReminder(message);
           return message.channel.send('Reminder enabled!');
         case 'disable':
           return message.channel.send('Reminder disabled!');

--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -36,8 +36,7 @@ module.exports = {
         case 'enable':
           return enableReminder(message);
         case 'disable':
-          disableReminder(message);
-          return message.channel.send('Reminder disabled!');
+          return disableReminder(message);
         default:
           return message.channel.send('Only accepts `enable` or `disable` as arguments');
       }

--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -1,4 +1,4 @@
-const { insertNewReminder, disableReminder, enableReminder } = require('../../database/reminder-db');
+const { disableReminder, enableReminder } = require('../../database/reminder-db');
 
 const reminderInstructions = () => {
   const embed ={
@@ -31,6 +31,12 @@ module.exports = {
   description : 'Activates a reminder inside a channel that pings users when world boss is spawning soon',
   hasArguments: true,
   execute(message, arguments, yagi, commands, yagiPrefix){
+    /**
+     * Accepts 1 argument which can either be 'enable' and 'disable' which fires the relevant functions
+     * If no argument is passed, a reminder instruction function is displayed
+     * To prevent channel spam and abuse, enabling/disabling reminders can only be used by admins
+     * For documentation of functions see reminder-db file
+     */
     const isAdmin = message.member.hasPermission("ADMINISTRATOR");
     if(arguments){
       switch (arguments) {

--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -1,4 +1,4 @@
-const { insertNewReminder, disableReminder } = require('../../database/reminder-db');
+const { insertNewReminder, disableReminder, enableReminder } = require('../../database/reminder-db');
 
 const reminderInstructions = () => {
   const embed ={
@@ -34,8 +34,7 @@ module.exports = {
     if(arguments){
       switch (arguments) {
         case 'enable':
-          insertNewReminder(message);
-          return message.channel.send('Reminder enabled!');
+          return enableReminder(message);
         case 'disable':
           disableReminder(message);
           return message.channel.send('Reminder disabled!');

--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -1,4 +1,4 @@
-const { insertNewReminder } = require('../../database/reminder-db');
+const { insertNewReminder, disableReminder } = require('../../database/reminder-db');
 
 const reminderInstructions = () => {
   const embed ={
@@ -31,13 +31,13 @@ module.exports = {
   description : 'Activates a reminder inside a channel that pings users when world boss is spawning soon',
   hasArguments: true,
   execute(message, arguments, yagi, commands, yagiPrefix){
-    console.log(message);
     if(arguments){
       switch (arguments) {
         case 'enable':
           insertNewReminder(message);
           return message.channel.send('Reminder enabled!');
         case 'disable':
+          disableReminder(message);
           return message.channel.send('Reminder disabled!');
         default:
           return message.channel.send('Only accepts `enable` or `disable` as arguments');

--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -31,12 +31,13 @@ module.exports = {
   description : 'Activates a reminder inside a channel that pings users when world boss is spawning soon',
   hasArguments: true,
   execute(message, arguments, yagi, commands, yagiPrefix){
+    const isAdmin = message.member.hasPermission("ADMINISTRATOR");
     if(arguments){
       switch (arguments) {
         case 'enable':
-          return enableReminder(message);
+          return isAdmin ? enableReminder(message) : message.channel.send('Reminders can only be enabled by an admin');
         case 'disable':
-          return disableReminder(message);
+          return isAdmin ? disableReminder(message) : message.channel.send('Reminders can only be disabled by an admin');
         default:
           return message.channel.send('Only accepts `enable` or `disable` as arguments');
       }

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -2,10 +2,11 @@ const sqlite = require('sqlite3').verbose();
 const { generateUUID } = require('../helpers');
 
 const createReminderTable = (database) => {
-  database.run('CREATE TABLE IF NOT EXISTS Reminder(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, enabled BOOLEAN NOT NULL, enabled_by TEXT, enabled_at DATE, disabled_by TEXT, disabled_at TEXT, type TEXT NOT NULL, role_id TEXT, channel_id TEXT, guild_id TEXT)');
+  database.run('CREATE TABLE IF NOT EXISTS Reminder(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, enabled BOOLEAN NOT NULL, enabled_by TEXT, enabled_at DATE, disabled_by TEXT, disabled_at DATE, type TEXT NOT NULL, role_id TEXT, channel_id TEXT, guild_id TEXT)');
 }
 const insertNewReminder = (message) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+
   database.run('INSERT INTO Reminder(uuid, created_at, enabled, enabled_by, enabled_at, disabled_by, disabled_at, type, role_id, channel_id, guild_id) VALUES ($uuid, $created_at, $enabled, $enabled_by, $enabled_at, $disabled_by, $disabled_at, $type, $role_id, $channel_id, $guild_id)', {
     $uuid: generateUUID(),
     $created_at: new Date(),
@@ -21,7 +22,21 @@ const insertNewReminder = (message) => {
   })
   console.log('inserted');
 }
+const enableReminder = () => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+}
+const disableReminder = (message, reminder) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+
+  database.run(`UPDATE Reminder SET enabled = ${false}, disabled_by = "${message.author.tag}", disabled_at = ${Date.now()} WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, err => {
+    if(err){
+      console.log(err);
+    }
+  })
+}
 module.exports = {
   createReminderTable,
-  insertNewReminder
+  insertNewReminder,
+  enableReminder,
+  disableReminder
 }

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -11,7 +11,7 @@ const insertNewReminder = (message) => {
     $uuid: generateUUID(),
     $created_at: new Date(),
     $enabled: true,
-    $enabled_by: message.author.tag,
+    $enabled_by: message.author.id,
     $enabled_at: new Date(),
     $disabled_by: null,
     $disabled_at: null,
@@ -20,15 +20,36 @@ const insertNewReminder = (message) => {
     $channel_id: message.channel.id,
     $guild_id: message.guild.id
   })
-  console.log('inserted');
 }
-const enableReminder = () => {
+const enableReminder = (message, reminder) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.serialize(() => {
+    database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, (error, row) => {
+      if(error){
+        console.log(error);
+      }
+      if(row){
+        if(row.enabled === 1){
+          message.channel.send("Already enabled");
+        } else {
+          database.run(`UPDATE Reminder SET enabled = ${true}, enabled_by = "${message.author.id}", enabled_at = ${Date.now()} WHERE uuid = "${row.uuid}"`, err => {
+            if(err){
+              console.log(err);
+            }
+            message.channel.send('Reminder enabled!');
+          })
+        }
+      } else {
+        insertNewReminder(message);
+        message.channel.send('Reminder enabled!');
+      }
+    })
+  })
 }
 const disableReminder = (message, reminder) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
 
-  database.run(`UPDATE Reminder SET enabled = ${false}, disabled_by = "${message.author.tag}", disabled_at = ${Date.now()} WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, err => {
+  database.run(`UPDATE Reminder SET enabled = ${false}, disabled_by = "${message.author.id}", disabled_at = ${Date.now()} WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, err => {
     if(err){
       console.log(err);
     }

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,11 +1,27 @@
 const sqlite = require('sqlite3').verbose();
+const { generateUUID } = require('../helpers');
 
 const createReminderTable = (database) => {
-  database.serialize(() => {
-    database.run('CREATE TABLE IF NOT EXISTS Reminder(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, enabled BOOLEAN NOT NULL, enabled_by TEXT, enabled_at DATE, disabled_by TEXT, disabled_at TEXT, type TEXT NOT NULL, role_id TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL)');
-  })
+  database.run('CREATE TABLE IF NOT EXISTS Reminder(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, enabled BOOLEAN NOT NULL, enabled_by TEXT, enabled_at DATE, disabled_by TEXT, disabled_at TEXT, type TEXT NOT NULL, role_id TEXT, channel_id TEXT, guild_id TEXT)');
 }
-
+const insertNewReminder = (message) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.run('INSERT INTO Reminder(uuid, created_at, enabled, enabled_by, enabled_at, disabled_by, disabled_at, type, role_id, channel_id, guild_id) VALUES ($uuid, $created_at, $enabled, $enabled_by, $enabled_at, $disabled_by, $disabled_at, $type, $role_id, $channel_id, $guild_id)', {
+    $uuid: generateUUID(),
+    $created_at: new Date(),
+    $enabled: true,
+    $enabled_by: message.author.tag,
+    $enabled_at: new Date(),
+    $disabled_by: null,
+    $disabled_at: null,
+    $type: 'channel',
+    $role_id: null,
+    $channel_id: message.channel.id,
+    $guild_id: message.guild.id
+  })
+  console.log('inserted');
+}
 module.exports = {
-  createReminderTable
+  createReminderTable,
+  insertNewReminder
 }

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,0 +1,11 @@
+const sqlite = require('sqlite3').verbose();
+
+const createReminderTable = (database) => {
+  database.serialize(() => {
+    database.run('CREATE TABLE IF NOT EXISTS Reminder(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, enabled BOOLEAN NOT NULL, enabled_by TEXT, enabled_at DATE, disabled_by TEXT, disabled_at TEXT, type TEXT NOT NULL, role_id TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL)');
+  })
+}
+
+module.exports = {
+  createReminderTable
+}

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -30,7 +30,7 @@ const enableReminder = (message, reminder) => {
       }
       if(row){
         if(row.enabled === 1){
-          message.channel.send("Already enabled");
+          message.channel.send("Already enabled!");
         } else {
           database.run(`UPDATE Reminder SET enabled = ${true}, enabled_by = "${message.author.id}", enabled_at = ${Date.now()} WHERE uuid = "${row.uuid}"`, err => {
             if(err){
@@ -49,10 +49,26 @@ const enableReminder = (message, reminder) => {
 const disableReminder = (message, reminder) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
 
-  database.run(`UPDATE Reminder SET enabled = ${false}, disabled_by = "${message.author.id}", disabled_at = ${Date.now()} WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, err => {
-    if(err){
-      console.log(err);
-    }
+  database.serialize(() => {
+    database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, (error, row) => {
+      if(error){
+        console.log(error);
+      }
+      if(row){
+        if(row.enabled === 0){
+          message.channel.send('This channel does not have reminders enabled!');
+        } else {
+          database.run(`UPDATE Reminder SET enabled = ${false}, disabled_by = "${message.author.id}", disabled_at = ${Date.now()} WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, err => {
+            if(err){
+              console.log(err);
+            }
+            message.channel.send('Reminder disabled!');
+          })
+        }
+      } else {
+        message.channel.send('This channel does not have reminders enabled!');
+      }
+    })
   })
 }
 module.exports = {

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,9 +1,18 @@
 const sqlite = require('sqlite3').verbose();
 const { generateUUID } = require('../helpers');
-
+/**
+ * Creates Reminder table inside the Yagi Database
+ * Gets called in the client.once('ready') hook
+ * Contrary to the other tables, we don't need to populate existing data from Discord as this is our own
+ * @param database - yagi database
+ */
 const createReminderTable = (database) => {
   database.run('CREATE TABLE IF NOT EXISTS Reminder(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, enabled BOOLEAN NOT NULL, enabled_by TEXT, enabled_at DATE, disabled_by TEXT, disabled_at DATE, type TEXT NOT NULL, role_id TEXT, channel_id TEXT, guild_id TEXT)');
 }
+/**
+ * Adds new reminder to Reminder Table
+ * @param message - message data object; taken from the on('message') event hook
+ */
 const insertNewReminder = (message) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
 
@@ -21,17 +30,26 @@ const insertNewReminder = (message) => {
     $guild_id: message.guild.id
   })
 }
-const enableReminder = (message, reminder) => {
+/**
+ * Function in charge of enabling reminders
+ * Either updates an existing reminder when it's disabled or calls the insertNewReminder function if it's a brand new reminder
+ * @param message - message data object; taken from the on('message') event hook
+ */
+const enableReminder = (message) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  //Wrapped in a serialize to ensure that each method is called in order which its initialised
   database.serialize(() => {
     database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, (error, row) => {
       if(error){
         console.log(error);
       }
+      //Checks if it's an existing reminder
       if(row){
+        //If it is, checks if the reminder is enabled
         if(row.enabled === 1){
           message.channel.send("Already enabled!");
         } else {
+          //Updates the reminder to enabled with relevant data
           database.run(`UPDATE Reminder SET enabled = ${true}, enabled_by = "${message.author.id}", enabled_at = ${Date.now()} WHERE uuid = "${row.uuid}"`, err => {
             if(err){
               console.log(err);
@@ -40,24 +58,36 @@ const enableReminder = (message, reminder) => {
           })
         }
       } else {
+        //Creates a new reminder if it doesn't exist
         insertNewReminder(message);
         message.channel.send('Reminder enabled!');
       }
     })
   })
 }
-const disableReminder = (message, reminder) => {
+/**
+ * Function in charge of disabling reminders
+ * Thought of either deleting the reminder or updating the enabled column when disabling
+ * Former would be easier to implement and maintain
+ * Latter would offer more flexibility with the data albeit more effort to implement
+ * Decided to go with updating just for the flexibility
+ * @param message - message data object; taken from the on('message') event hook
+ */
+const disableReminder = (message) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-
+  //Wrapped in a serialize to ensure that each method is called in order which its initialised
   database.serialize(() => {
     database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, (error, row) => {
       if(error){
         console.log(error);
       }
+      //Checks if it's an existing reminder
       if(row){
+        //If it is, checks if reminder is disabled
         if(row.enabled === 0){
           message.channel.send('This channel does not have reminders enabled!');
         } else {
+          //Updates the reminder to disabled with relevant data
           database.run(`UPDATE Reminder SET enabled = ${false}, disabled_by = "${message.author.id}", disabled_at = ${Date.now()} WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, err => {
             if(err){
               console.log(err);

--- a/yagi.js
+++ b/yagi.js
@@ -8,6 +8,7 @@ const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment } = requ
 const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildMemberCount } = require('./database/guild-db.js');
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
+const { createReminderTable } = require('./database/reminder-db.js');
 const { sendMixpanelEvent } = require('./analytics');
 
 const activitylist = [
@@ -68,6 +69,7 @@ yagi.once('ready', () => {
     createGuildTable(yagiDatabase, yagi.guilds.cache, yagi);
     createChannelTable(yagiDatabase, yagi.channels.cache, yagi);
     createRoleTable(yagiDatabase, yagi.guilds.cache);
+    createReminderTable(yagiDatabase);
     /**
      * Changes Yagi's activity every 2 minutes on random
      * Starts on the first index of the activityList array and then sets to a different one after


### PR DESCRIPTION
#### Context
Create Reminder Table in the database along with its relevant statements; insert new reminder, update reminder when enabling and update reminder when disabling. Columns used 

- uuid (Primary key)
- created_at,
- enabled
- enabled_by,
- enabled_at,
- disabled_by
- disabled_at,
- type
- role_id,
- channel_id,
- guild_id

Separated data for enable/disable columns instead of having a shared interacted_last column for more flexibility. Role is kept null for now, will be updating once the Goat Hunter role creation gets implemented. 

Also added a check to only let admins enable or disable reminders to prevent spam and commands abuse.

![image](https://user-images.githubusercontent.com/42207245/125182514-37b08900-e241-11eb-97b2-2da792e1fbae.png)

#### Change
- Create reminder table
- Create insert new, disable and enable function statements
- Only give reminders access to admins

#### Release Notes
Create reminder table in database