### PR TITLE
Create Reminder role

### DIFF
--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -58,6 +58,11 @@ const enableReminder = (message) => {
         if(reminder.enabled === 1){
           message.channel.send("Already enabled!");
         } else {
+          /**
+           * Additional call to the Role Table to check if the role associated with the reminder still exists and hasn't been deleted
+           * If it does exist, we don't do anything and update the reminder to its enable state
+           * If it has been deleted, we call the createReminderRole to create a new role and link it with the reminder before updating it to its enable state
+           */
           database.serialize(() => {
             database.get(`SELECT * FROM Role WHERE uuid = "${reminder.role_uuid}"`, (err, role) => {
               if(err){

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -8,7 +8,7 @@ const { createReminderRole } = require('./role-db');
  * @param database - yagi database
  */
 const createReminderTable = (database) => {
-  database.run('CREATE TABLE IF NOT EXISTS Reminder(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, enabled BOOLEAN NOT NULL, enabled_by TEXT, enabled_at DATE, disabled_by TEXT, disabled_at DATE, type TEXT NOT NULL, role_id TEXT, channel_id TEXT, guild_id TEXT)');
+  database.run('CREATE TABLE IF NOT EXISTS Reminder(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, enabled BOOLEAN NOT NULL, enabled_by TEXT, enabled_at DATE, disabled_by TEXT, disabled_at DATE, type TEXT NOT NULL, role_uuid TEXT, channel_id TEXT, guild_id TEXT)');
 }
 /**
  * Adds new reminder to Reminder Table
@@ -19,7 +19,7 @@ const insertNewReminder = (message) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   const reminderUUID = generateUUID();
   database.serialize(() => {
-    database.run('INSERT INTO Reminder(uuid, created_at, enabled, enabled_by, enabled_at, disabled_by, disabled_at, type, role_id, channel_id, guild_id) VALUES ($uuid, $created_at, $enabled, $enabled_by, $enabled_at, $disabled_by, $disabled_at, $type, $role_id, $channel_id, $guild_id)', {
+    database.run('INSERT INTO Reminder(uuid, created_at, enabled, enabled_by, enabled_at, disabled_by, disabled_at, type, role_uuid, channel_id, guild_id) VALUES ($uuid, $created_at, $enabled, $enabled_by, $enabled_at, $disabled_by, $disabled_at, $type, $role_uuid, $channel_id, $guild_id)', {
       $uuid: reminderUUID,
       $created_at: new Date(),
       $enabled: true,
@@ -28,7 +28,7 @@ const insertNewReminder = (message) => {
       $disabled_by: null,
       $disabled_at: null,
       $type: 'channel',
-      $role_id: null,
+      $role_uuid: null,
       $channel_id: message.channel.id,
       $guild_id: message.guild.id
     }, err => {

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -94,10 +94,36 @@ const updateRole = (role) => {
     }
   })
 }
-
+/**
+ * Create role to be used by yagi for reminders
+ * Uses update instead of inserting new row in table as the roleCreate event when creating a the new role
+ * To prevent duplicate roles from being inserted into the table, we update the created role from the insertNewRole function with the relevant data
+ * @param guild - current guild object; needed to create a role
+ * @param reminderID - reminder id
+ */
+const createReminderRole = async (guild, reminderID) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  try {
+    const reminderRole = await guild.roles.create({
+      data: {
+        name: 'Goat Hunters',
+        color: '#68d5e9'
+      },
+      reason: 'Role to be used by Yagi for automated reminders for Vulture Vale/Blizzard Berg World Boss'
+    })
+    database.run(`UPDATE Role SET reminder_id = "${reminderID}", used_for_reminder = ${true} WHERE role_id = ${reminderRole.id} AND guild_id = ${reminderRole.guild.id}`, err => {
+      if(err){
+        console.log(err);
+      }
+    })
+  } catch(e){
+    console.log(e);
+  }
+}
 module.exports = {
   createRoleTable,
   insertNewRole,
   deleteRole,
-  updateRole
+  updateRole,
+  createReminderRole
 }

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -111,10 +111,26 @@ const createReminderRole = async (guild, reminderID) => {
       },
       reason: 'Role to be used by Yagi for automated reminders for Vulture Vale/Blizzard Berg World Boss'
     })
-    database.run(`UPDATE Role SET reminder_id = "${reminderID}", used_for_reminder = ${true} WHERE role_id = ${reminderRole.id} AND guild_id = ${reminderRole.guild.id}`, err => {
-      if(err){
-        console.log(err);
-      }
+    database.serialize(() => {
+      database.get(`SELECT * FROM Role WHERE role_id = ${reminderRole.id} AND guild_id = ${reminderRole.guild.id}`, (error, row) => {
+        if(error){
+          console.log(error);
+        }
+        if(row){
+          //Update reminder role with relevant data
+          database.run(`UPDATE Role SET reminder_id = "${reminderID}", used_for_reminder = ${true} WHERE uuid = "${row.uuid}"`, err => {
+            if(err){
+              console.log(err);
+            }
+          })
+          //Update Reminder with created role
+          database.run(`UPDATE Reminder SET role_uuid = "${row.uuid}" where uuid = "${reminderID}"`, err => {
+            if(err){
+              console.log(err);
+            }
+          })
+        }
+      })
     })
   } catch(e){
     console.log(e);


### PR DESCRIPTION
#### Context
As Yagi would need someway of notifying users when world boss is spawning soon, I decided to use a custom role instead of the generic `@everyone`/`@here`. It is more straightforward to just ping all the members of a server but I find it more intuitive to give a choice to users if they want to get notified or not. Thanks Persephone bot for giving me inspiration for the idea.

Pretty straightforward path of how the role gets created

1. When creating a new reminder -> Creates reminder role and link it with the reminder
2. When disabling a reminder -> Don't delete role
3. When enabling a reminder -> Find the role first in our database; do nothing if it exists, do 1. if it doesn't

Settled with the name Goat Hunters for now but might change it before release. In any case, admins can change the role of the name anyway so it doesn't really matter
![image](https://user-images.githubusercontent.com/42207245/125214080-b6f89800-e2e7-11eb-96b8-e1cae79117a8.png)
![image](https://user-images.githubusercontent.com/42207245/125214087-c841a480-e2e7-11eb-9f65-f3a1c80c8574.png)

#### Change
- Create reminder role when newly creating a reminder
- Check if role was deleted when enabling a reminder and create a new one if it was
- Refactor db functions

#### Release Notes
Create `@Goat Hunters` role when creating a reminder