### PR TITLE
Design reminder embeds

### DIFF
--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -1,30 +1,4 @@
-const { disableReminder, enableReminder } = require('../../database/reminder-db');
-
-const reminderInstructions = () => {
-  const embed ={
-    "description": "Personal reminder to notify you when world boss is spawning soon.\nCan only be activated in one channel per server by an admin.\n\n",
-    "color": 32896,
-    thumbnail: {
-      url:
-        'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png'
-    },
-    "fields": [
-      {
-        "name": "How to enable:",
-        "value": "1. In the channel you want to get notifications from, type `$yagi-remind enable`. This will activate reminders on the current channel.\n2. When a channel is successfully activated, a special message is sent to the channel with details about the reminder."
-      },
-      {
-        "name": "How to use",
-        "value": "1. When a channel is activated, Yagi creates a new role in the server `@Goat Hunters`\n2. To get reminders, simply react on the special message with :goat: and you will automatically get the role. *Note that by removing the reaction you will lose the role*\n3. When world boss is spawning soon, Yagi will ping the role\n\n*To get the special message again, type `$yagi-remind`. You can also edit the role to customise its name/color*"
-      },
-      {
-        "name": "How to disable",
-        "value": "1. Type `$yagi-remind disable` in the channel where reminders was enabled. This will deactivate reminders on the current channel.\n2. When a channel is succesfully deactivated, the `@Goat Hunters` role will be deleted"
-      }
-    ]
-  }
-  return embed;
-}
+const { disableReminder, enableReminder, sendReminderInformation } = require('../../database/reminder-db');
 
 module.exports = {
   name: 'remind',
@@ -48,8 +22,7 @@ module.exports = {
           return message.channel.send('Only accepts `enable` or `disable` as arguments');
       }
     } else {
-      const embed = reminderInstructions();
-      message.channel.send({ embed });
+      sendReminderInformation(message);
     }
   }
 }

--- a/database/guild-db.js
+++ b/database/guild-db.js
@@ -1,5 +1,6 @@
 const sqlite = require('sqlite3').verbose();
-const { sendGuildUpdateNotification } = require('../helpers');
+const { sendGuildUpdateNotification} = require('../helpers');
+const { defaultPrefix } = require('../config/yagi.json');
 
 /**
  * Creates Guild table inside the Yagi Database
@@ -12,7 +13,7 @@ const createGuildTable = (database, guilds, client) => {
   //Wrapped in a serialize to ensure that each method is called in order which its initialised
   database.serialize(() => { 
     //Creates Guild Table with the relevant columns if it does not exist
-    database.run('CREATE TABLE IF NOT EXISTS Guild(uuid TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, member_count INTEGER NOT NULL, region TEXT NOT NULL, owner_id TEXT NOT NULL)');
+    database.run('CREATE TABLE IF NOT EXISTS Guild(uuid TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, member_count INTEGER NOT NULL, region TEXT NOT NULL, owner_id TEXT NOT NULL, prefix TEXT NOT NULL)');
     
     //Populate Guild Table with existing guilds
     guilds.forEach(guild => {
@@ -22,12 +23,13 @@ const createGuildTable = (database, guilds, client) => {
         }
         //Only runs statement and insert into guild table if the guild hasn't been created yet
         if(!row){
-          database.run('INSERT INTO Guild (uuid, name, member_count, region, owner_id) VALUES ($uuid, $name, $member_count, $region, $owner_id)', {
+          database.run('INSERT INTO Guild (uuid, name, member_count, region, owner_id, prefix) VALUES ($uuid, $name, $member_count, $region, $owner_id, $prefix)', {
             $uuid: guild.id,
             $name: guild.name,
             $member_count: guild.memberCount,
             $region: guild.region,
-            $owner_id: guild.ownerID
+            $owner_id: guild.ownerID,
+            $prefix: defaultPrefix
           }, err => {
             if(err){
               console.log(err);
@@ -45,12 +47,13 @@ const createGuildTable = (database, guilds, client) => {
  */
 const insertNewGuild = (guild) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.run('INSERT INTO Guild (uuid, name, member_count, region, owner_id) VALUES ($uuid, $name, $member_count, $region, $owner_id)', {
+  database.run('INSERT INTO Guild (uuid, name, member_count, region, owner_id, prefix) VALUES ($uuid, $name, $member_count, $region, $owner_id, $prefix)', {
     $uuid: guild.id,
     $name: guild.name,
     $member_count: guild.memberCount,
     $region: guild.region,
-    $owner_id: guild.ownerID
+    $owner_id: guild.ownerID,
+    $prefix: defaultPrefix
   }, err => {
     if(err){
       console.log(err);

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -35,6 +35,12 @@ const insertNewReminder = (message) => {
       if(err){
         console.log(err);
       }
+      const embed = {
+        title: "Reminder Enabled!",
+        description: "I will notify you in this channel before world boss spawns!",
+        color: 55296
+      }
+      message.channel.send({ embed });
     })
     createReminderRole(message.guild, reminderUUID);
   })
@@ -48,44 +54,49 @@ const enableReminder = (message) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   //Wrapped in a serialize to ensure that each method is called in order which its initialised
   database.serialize(() => {
-    database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, (error, reminder) => {
+    database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND enabled = ${true}`, (error, enabledReminder) => {
       if(error){
         console.log(error);
       }
-      const embed = enableReminderEmbed(message, reminder);
-      //Checks if it's an existing reminder
-      if(reminder){
-        //If it is, checks if the reminder is enabled
-        if(reminder.enabled === 1){
-          message.channel.send({ embed });
-        } else {
-          /**
-           * Additional call to the Role Table to check if the role associated with the reminder still exists and hasn't been deleted
-           * If it does exist, we don't do anything and update the reminder to its enable state
-           * If it has been deleted, we call the createReminderRole to create a new role and link it with the reminder before updating it to its enable state
-           */
-          database.serialize(() => {
-            database.get(`SELECT * FROM Role WHERE uuid = "${reminder.role_uuid}"`, (err, role) => {
-              if(err){
-                console.log(err);
-              }
-              if(!role){
-                createReminderRole(message.guild, reminder.uuid);
-              }
-            })
-            //Updates the reminder to enabled with relevant data
-            database.run(`UPDATE Reminder SET enabled = ${true}, enabled_by = "${message.author.id}", enabled_at = ${Date.now()} WHERE uuid = "${reminder.uuid}"`, err => {
-              if(err){
-                console.log(err);
-              }
-              message.channel.send({ embed });
-            })
-          })
-        }
+
+      if(enabledReminder){
+        const embed = enableReminderEmbed(message, enabledReminder)
+        message.channel.send({ embed })
       } else {
-        //Creates a new reminder if it doesn't exist
-        insertNewReminder(message);
-        message.channel.send({ embed });
+        database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND channel_id = ${message.channel.id}`, (error, reminder) => {
+          if(error){
+            console.log(error);
+          }
+          //Checks if it's an existing reminder
+          if(reminder){
+            /**
+             * Additional call to the Role Table to check if the role associated with the reminder still exists and hasn't been deleted
+             * If it does exist, we don't do anything and update the reminder to its enable state
+             * If it has been deleted, we call the createReminderRole to create a new role and link it with the reminder before updating it to its enable state
+             */
+            database.serialize(() => {
+              database.get(`SELECT * FROM Role WHERE uuid = "${reminder.role_uuid}"`, (err, role) => {
+                if(err){
+                  console.log(err);
+                }
+                if(!role){
+                  createReminderRole(message.guild, reminder.uuid);
+                }
+              })
+              //Updates the reminder to enabled with relevant data
+              database.run(`UPDATE Reminder SET enabled = ${true}, enabled_by = "${message.author.id}", enabled_at = ${Date.now()} WHERE uuid = "${reminder.uuid}"`, err => {
+                if(err){
+                  console.log(err);
+                }
+                const embed = enableReminderEmbed(message, reminder)
+                message.channel.send({ embed });
+              })
+            })
+          } else {
+            //Creates a new reminder if it doesn't exist
+            insertNewReminder(message);
+          }
+        })
       }
     })
   })

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,5 +1,5 @@
 const sqlite = require('sqlite3').verbose();
-const { generateUUID, disableReminderEmbed } = require('../helpers');
+const { generateUUID, disableReminderEmbed, enableReminderEmbed } = require('../helpers');
 const { createReminderRole } = require('./role-db');
 /**
  * Creates Reminder table inside the Yagi Database
@@ -52,11 +52,12 @@ const enableReminder = (message) => {
       if(error){
         console.log(error);
       }
+      const embed = enableReminderEmbed(message, reminder);
       //Checks if it's an existing reminder
       if(reminder){
         //If it is, checks if the reminder is enabled
         if(reminder.enabled === 1){
-          message.channel.send("Already enabled!");
+          message.channel.send({ embed });
         } else {
           /**
            * Additional call to the Role Table to check if the role associated with the reminder still exists and hasn't been deleted
@@ -77,14 +78,14 @@ const enableReminder = (message) => {
               if(err){
                 console.log(err);
               }
-              message.channel.send('Reminder enabled!');
+              message.channel.send({ embed });
             })
           })
         }
       } else {
         //Creates a new reminder if it doesn't exist
         insertNewReminder(message);
-        message.channel.send('Reminder enabled!');
+        message.channel.send({ embed });
       }
     })
   })

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -156,8 +156,13 @@ const sendReminderInformation = (message) => {
       console.log(error)
     }
     if(enabledReminder){
-      const embed = reminderDetails();
-      message.channel.send({ embed })
+      database.get(`SELECT * FROM Role WHERE uuid = "${enabledReminder.role_uuid}"`, (error, role) => {
+        if(error){
+          console.log(error);
+        }
+        const embed = reminderDetails(enabledReminder.channel_id, role.role_id);
+        message.channel.send({ embed })
+      })
     } else {
       const embed = reminderInstructions();
       message.channel.send({ embed });

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,5 +1,5 @@
 const sqlite = require('sqlite3').verbose();
-const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions } = require('../helpers');
+const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails } = require('../helpers');
 const { createReminderRole } = require('./role-db');
 /**
  * Creates Reminder table inside the Yagi Database
@@ -156,7 +156,8 @@ const sendReminderInformation = (message) => {
       console.log(error)
     }
     if(enabledReminder){
-      message.channel.send('Reminder Information')
+      const embed = reminderDetails();
+      message.channel.send({ embed })
     } else {
       const embed = reminderInstructions();
       message.channel.send({ embed });

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -35,6 +35,9 @@ const insertNewReminder = (message) => {
       if(err){
         console.log(err);
       }
+      /**
+       * Wrote an individual embed instead of using the function for better readability
+       */
       const embed = {
         title: "Reminder Enabled!",
         description: "I will notify you in this channel before world boss spawns!",
@@ -46,6 +49,7 @@ const insertNewReminder = (message) => {
   })
 }
 /**
+ * **REFACTOR: Make it more easily readable**
  * Function in charge of enabling reminders
  * Either updates an existing reminder when it's disabled or calls the insertNewReminder function if it's a brand new reminder
  * @param message - message data object; taken from the on('message') event hook
@@ -54,6 +58,13 @@ const enableReminder = (message) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   //Wrapped in a serialize to ensure that each method is called in order which its initialised
   database.serialize(() => {
+    /**
+     * To lessen the amount of ping spam that might arise when enabling multiple channels within a guild to have reminders, I've decided to only limit the amount of active reminders to 1 at a time
+     * Wrapped the enabling functions with an outer check of the database if there are any reminders that are active inside the server
+     * If there is already, we send an embed notifying them there is already an active reminder
+     * If there isn't, we then have an additional check to see if the channel they are in is already in our database
+     * We update the data to its enabled state if it exists, create a new reminder in the database if it doesn't
+     */
     database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND enabled = ${true}`, (error, enabledReminder) => {
       if(error){
         console.log(error);

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,5 +1,5 @@
 const sqlite = require('sqlite3').verbose();
-const { generateUUID, disableReminderEmbed, enableReminderEmbed } = require('../helpers');
+const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions } = require('../helpers');
 const { createReminderRole } = require('./role-db');
 /**
  * Creates Reminder table inside the Yagi Database
@@ -149,9 +149,24 @@ const disableReminder = (message) => {
     })
   })
 }
+const sendReminderInformation = (message) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND enabled = ${true}`, (error, enabledReminder) => {
+    if(error){
+      console.log(error)
+    }
+    if(enabledReminder){
+      message.channel.send('Reminder Information')
+    } else {
+      const embed = reminderInstructions();
+      message.channel.send({ embed });
+    }
+  })
+}
 module.exports = {
   createReminderTable,
   insertNewReminder,
   enableReminder,
-  disableReminder
+  disableReminder,
+  sendReminderInformation
 }

--- a/helpers.js
+++ b/helpers.js
@@ -12,7 +12,6 @@ const {
 } = require('date-fns');
 const { v4: uuidv4 } = require('uuid');
 const { currentOffset } = require('./config/offset.json');
-const sqlite = require('sqlite3').verbose();
 const grvAcnt = '`';
 
 //----------
@@ -297,6 +296,32 @@ const enableReminderEmbed = (message, reminder) => {
   return embed;
 }
 //----------
+const reminderInstructions = () => {
+  const embed = {
+    "description": "Personal reminder to notify you when world boss is spawning soon.\nCan only be activated in one channel per server by an admin.\n\n",
+    "color": 32896,
+    thumbnail: {
+      url:
+        'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png'
+    },
+    "fields": [
+      {
+        "name": "How to enable:",
+        "value": "1. In the channel you want to get notifications from, type `$yagi-remind enable`. This will activate reminders on the current channel.\n2. When a channel is successfully activated, a special message is sent to the channel with details about the reminder."
+      },
+      {
+        "name": "How to use",
+        "value": "1. When a channel is activated, Yagi creates a new role in the server `@Goat Hunters`\n2. To get reminders, simply react on the special message with :goat: and you will automatically get the role. *Note that by removing the reaction you will lose the role*\n3. When world boss is spawning soon, Yagi will ping the role\n\n*To get the special message again, type `$yagi-remind`. You can also edit the role to customise its name/color*"
+      },
+      {
+        "name": "How to disable",
+        "value": "1. Type `$yagi-remind disable` in the channel where reminders was enabled. This will deactivate reminders on the current channel."
+      }
+    ]
+  }
+  return embed;
+}
+//----------
 module.exports = {
   getServerTime,
   formatCountdown,
@@ -309,5 +334,6 @@ module.exports = {
   sendErrorLog,
   generateUUID,
   disableReminderEmbed,
-  enableReminderEmbed
-};
+  enableReminderEmbed,
+  reminderInstructions
+}

--- a/helpers.js
+++ b/helpers.js
@@ -12,6 +12,7 @@ const {
 } = require('date-fns');
 const { v4: uuidv4 } = require('uuid');
 const { currentOffset } = require('./config/offset.json');
+const sqlite = require('sqlite3').verbose();
 const grvAcnt = '`';
 
 //----------
@@ -247,9 +248,9 @@ const generateUUID = () => {
  * Embed design used when disabling reminders
  * First checks if message was sent in the reminder-enabled channel and if reminder even exists
  * If it does, we check if it the reminder is enabled and send an embed notifying the reminder has been disabled
- * If it's not sent in the enabled channel or if reminder doesn't exist, we send an embed notifying user that there are no active reminder in the channel
+ * If it's not sent in the enabled channel or if reminder doesn't exist, we send an embed notifying user that there are no active reminders in the channel
  * @param message - message data object
- * @param message - reminder to be disabled 
+ * @param reminder - reminder to be disabled 
  */
 const disableReminderEmbed = (message, reminder) => {
   let embed;
@@ -269,6 +270,14 @@ const disableReminderEmbed = (message, reminder) => {
   }
   return embed;
 }
+/**
+ * Embed design used when enabling reminders
+ * First checks if message was sent in the reminder-enabled channel and if reminder even exists
+ * If it does, we check if it the reminder is disabled and send an embed notifying the reminder has been enabled
+ * If it's not sent in the enabled channel or if reminder doesn't exist, we send an embed notifying user that there are no active reminders in the channel
+ * @param message - message data object
+ * @param reminder - reminder to be disabled  
+ */
 const enableReminderEmbed = (message, reminder) => {
   let embed;
   const sentInEnabledChannel = reminder ? message.channel.id === reminder.channel_id : null;

--- a/helpers.js
+++ b/helpers.js
@@ -243,6 +243,33 @@ const generateUUID = () => {
   return uuidv4();
 }
 //----------
+/**
+ * Embed design used when disabling reminders
+ * First checks if message was sent in the reminder-enabled channel and if reminder even exists
+ * If it does, we check if it the reminder is enabled and send an embed notifying the reminder has been disabled
+ * If it's not sent in the enabled channel or if reminder doesn't exist, we send an embed notifying user that there are no active reminder in the channel
+ * @param message - message data object
+ * @param message - reminder to be disabled 
+ */
+const disableReminderEmbed = (message, reminder) => {
+  let embed;
+  const sentInEnabledChannel = reminder ? message.channel.id === reminder.channel_id : null;
+  if(sentInEnabledChannel && reminder.enabled === 1){
+    embed = {
+      title: "Reminder disabled!",
+      description: "I will no longer notify you in this channel",
+      color: 32896
+    }
+  } else {
+    embed = {
+      title: "Whoops!",
+      description: "There are no active reminders in this channel",
+      color: 32896
+    }
+  }
+  return embed;
+}
+//----------
 module.exports = {
   getServerTime,
   formatCountdown,
@@ -253,5 +280,6 @@ module.exports = {
   checkIfInDevelopment,
   sendGuildUpdateNotification,
   sendErrorLog,
-  generateUUID
+  generateUUID,
+  disableReminderEmbed
 };

--- a/helpers.js
+++ b/helpers.js
@@ -327,7 +327,7 @@ const reminderInstructions = () => {
   return embed;
 }
 //----------
-const reminderDetails = (role) => {
+const reminderDetails = (channel, role) => {
   const embed = {
     color: 32896,
     description: "Below are the details used for reminders. To get notified, react to this message with :goat: and you will get the role!\n\n*Note that by removing the reaction you will lose the role*",
@@ -338,12 +338,12 @@ const reminderDetails = (role) => {
     fields: [
       {
         name: "Active Channel",
-        value: "channel",
+        value: `<#${channel}>`,
         inline: true
       },
       {
         name: "Reminder Role",
-        value: "role",
+        value: `<@&${role}>`,
         inline: true
       }
     ]

--- a/helpers.js
+++ b/helpers.js
@@ -258,12 +258,30 @@ const disableReminderEmbed = (message, reminder) => {
     embed = {
       title: "Reminder disabled!",
       description: "I will no longer notify you in this channel",
-      color: 32896
+      color: 16711680
     }
   } else {
     embed = {
       title: "Whoops!",
       description: "There are no active reminders in this channel",
+      color: 32896
+    }
+  }
+  return embed;
+}
+const enableReminderEmbed = (message, reminder) => {
+  let embed;
+  const sentInEnabledChannel = reminder ? message.channel.id === reminder.channel_id : null;
+  if(sentInEnabledChannel && reminder.enabled === 0) {
+    embed = {
+      title: "Reminder Enabled!",
+      description: "I will notify you in this channel before world boss spawns!",
+      color: 55296
+    }
+  } else {
+    embed = {
+      title: "Whoops!",
+      description: "There is already an active reminder in this server! To see the reminder information, type `$yagi-remind`",
       color: 32896
     }
   }
@@ -281,5 +299,6 @@ module.exports = {
   sendGuildUpdateNotification,
   sendErrorLog,
   generateUUID,
-  disableReminderEmbed
+  disableReminderEmbed,
+  enableReminderEmbed
 };

--- a/helpers.js
+++ b/helpers.js
@@ -289,33 +289,62 @@ const enableReminderEmbed = (message, reminder) => {
   } else {
     embed = {
       title: "Whoops!",
-      description: "There is already an active reminder in this server! To see the reminder information, type `$yagi-remind`",
+      description: "There is already an active reminder in this server! To see the reminder details, type `$yagi-remind`",
       color: 32896
     }
   }
   return embed;
 }
 //----------
+/**
+ * Embed design used for onboarding users on how to use reminders
+ * Tried to be as detailed as possible but still not sure if it would be complicated for users to get it
+ * Debating if I have to do a support doc or make a video about it
+ */
 const reminderInstructions = () => {
   const embed = {
-    "description": "Personal reminder to notify you when world boss is spawning soon.\nCan only be activated in one channel per server by an admin.\n\n",
-    "color": 32896,
+    description: "Personal reminder to notify you when world boss is spawning soon.\nCan only be activated in one channel per server by an admin.\n\n",
+    color: 32896,
     thumbnail: {
       url:
         'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png'
     },
-    "fields": [
+    fields: [
       {
-        "name": "How to enable:",
-        "value": "1. In the channel you want to get notifications from, type `$yagi-remind enable`. This will activate reminders on the current channel.\n2. When a channel is successfully activated, a special message is sent to the channel with details about the reminder."
+        name: "How to enable:",
+        value: "1. In the channel you want to get notifications from, type `$yagi-remind enable`. This will activate reminders on the current channel.\n2. When a channel is successfully activated, a special message is sent to the channel with details about the reminder."
       },
       {
-        "name": "How to use",
-        "value": "1. When a channel is activated, Yagi creates a new role in the server `@Goat Hunters`\n2. To get reminders, simply react on the special message with :goat: and you will automatically get the role. *Note that by removing the reaction you will lose the role*\n3. When world boss is spawning soon, Yagi will ping the role\n\n*To get the special message again, type `$yagi-remind`. You can also edit the role to customise its name/color*"
+        name: "How to use",
+        value: "1. When a channel is activated, Yagi creates a new role in the server `@Goat Hunters`\n2. To get reminders, simply react on the special message with :goat: and you will automatically get the role. *Note that by removing the reaction you will lose the role*\n3. When world boss is spawning soon, Yagi will ping the role\n\n*To get the special message again, type `$yagi-remind`. You can also edit the role to customise its name/color*"
       },
       {
-        "name": "How to disable",
-        "value": "1. Type `$yagi-remind disable` in the channel where reminders was enabled. This will deactivate reminders on the current channel."
+        name: "How to disable",
+        value: "1. Type `$yagi-remind disable` in the channel where reminders was enabled. This will deactivate reminders on the current channel."
+      }
+    ]
+  }
+  return embed;
+}
+//----------
+const reminderDetails = (role) => {
+  const embed = {
+    color: 32896,
+    description: "Below are the details used for reminders. To get notified, react to this message with :goat: and you will get the role!\n\n*Note that by removing the reaction you will lose the role*",
+    thumbnail: {
+      url:
+        'https://cdn.discordapp.com/attachments/248430185463021569/864309441821802557/goat-timer_logo_dark2_reminder.png'
+    },
+    fields: [
+      {
+        name: "Active Channel",
+        value: "channel",
+        inline: true
+      },
+      {
+        name: "Reminder Role",
+        value: "role",
+        inline: true
       }
     ]
   }
@@ -335,5 +364,6 @@ module.exports = {
   generateUUID,
   disableReminderEmbed,
   enableReminderEmbed,
-  reminderInstructions
+  reminderInstructions,
+  reminderDetails
 }

--- a/yagi.js
+++ b/yagi.js
@@ -206,6 +206,7 @@ yagi.on('message', async (message) => {
     }
     message.channel.send('My bad! I only work in server channels ( ≧Д≦)');
     sendMixpanelEvent(message.author, message.channel, guildDM, '', mixpanel);
+    return;
   }
 
   const yagiPrefix = defaultPrefix; //Keeping this way for now to remind myself to add a better way for custom prefixes


### PR DESCRIPTION
#### Context
Was once only a pr about designing embeds have transformed into also fleshing out reminder utilisation. Added multiple conditions and database checks for only allowing 1 reminder per server and updating reminders with existing roles or when reminder roles get deleted. Embed Designs:

- `remind enable`
![image](https://user-images.githubusercontent.com/42207245/125401443-c4944780-e3e5-11eb-9cd3-0266faab54c2.png)
- `remind disable`
![image](https://user-images.githubusercontent.com/42207245/125401491-d118a000-e3e5-11eb-93da-9f88edc778ee.png)
-  `remind enable` when there is already an active reminder
![image](https://user-images.githubusercontent.com/42207245/125401854-46847080-e3e6-11eb-9727-c2bdc531a141.png)
-  `remind disable` when there is no active reminders in current channel/in server
![image](https://user-images.githubusercontent.com/42207245/125401904-556b2300-e3e6-11eb-8d09-3d1ca45580d2.png)
- `remind` when there is an active reminder
![image](https://user-images.githubusercontent.com/42207245/125401811-39678180-e3e6-11eb-84d8-9c0e444b26f6.png)

#### Change
- Create embed design for when disabling reminders
- Create embed design for enabling reminders
- Only allow 1 reminder to be active in a server
- Add condition to show reminder instructions or reminder details based on reminder being active
- Use existing role when enabling a new reminder channel instead of creating a new one

#### Release Notes
Design Reminder Embeds