### PR TITLE
Set roles when reacting

### DIFF
--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -22,7 +22,7 @@ module.exports = {
           return message.channel.send('Only accepts `enable` or `disable` as arguments');
       }
     } else {
-      sendReminderInformation(message);
+      sendReminderInformation(message, yagi);
     }
   }
 }

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,6 +1,7 @@
 const sqlite = require('sqlite3').verbose();
 const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails } = require('../helpers');
 const { createReminderRole } = require('./role-db');
+const { insertNewReminderDetails } = require('./reminder-details-db');
 /**
  * Creates Reminder table inside the Yagi Database
  * Gets called in the client.once('ready') hook
@@ -184,6 +185,7 @@ const sendReminderInformation = (message) => {
         const embed = reminderDetails(enabledReminder.channel_id, role.role_id);
         const messageDetail = await message.channel.send({ embed })
         await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
+        insertNewReminderDetails(messageDetail, message.author);
       })
     } else {
       const embed = reminderInstructions();

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -177,12 +177,13 @@ const sendReminderInformation = (message) => {
       console.log(error)
     }
     if(enabledReminder){
-      database.get(`SELECT * FROM Role WHERE uuid = "${enabledReminder.role_uuid}"`, (error, role) => {
+      database.get(`SELECT * FROM Role WHERE uuid = "${enabledReminder.role_uuid}"`, async (error, role) => {
         if(error){
           console.log(error);
         }
         const embed = reminderDetails(enabledReminder.channel_id, role.role_id);
-        message.channel.send({ embed })
+        const messageDetail = await message.channel.send({ embed })
+        await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
       })
     } else {
       const embed = reminderInstructions();

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,7 +1,7 @@
 const sqlite = require('sqlite3').verbose();
 const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails } = require('../helpers');
 const { createReminderRole } = require('./role-db');
-const { insertNewReminderDetails } = require('./reminder-details-db');
+const { insertNewReminderDetails } = require('./reminder-reaction-message-db.js');
 /**
  * Creates Reminder table inside the Yagi Database
  * Gets called in the client.once('ready') hook
@@ -184,8 +184,8 @@ const sendReminderInformation = (message) => {
         }
         const embed = reminderDetails(enabledReminder.channel_id, role.role_id);
         const messageDetail = await message.channel.send({ embed })
-        await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
-        insertNewReminderDetails(messageDetail, message.author);
+        // await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
+        // insertNewReminderDetails(messageDetail, message.author);
       })
     } else {
       const embed = reminderInstructions();

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -62,6 +62,12 @@ const enableReminder = (message) => {
                   console.log(err);
                 }
                 if(role){
+                  /**
+                   * We send our reminder reaction message only after a reminder gets enabled
+                   * This is to collect reactions that yagi will use to set the reminder role
+                   * Yagi reacts to the message by default after sending it so users won't have to find the reaction
+                   * By design and discord's api limitation, there will only be one reminder reaction message per server. 
+                  */
                   const embed = reminderReactionMessage(reminder.channel_id, role.role_id);
                   const messageDetail = await message.channel.send({ embed })
                   await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
@@ -181,6 +187,13 @@ const disableReminder = (message) => {
     })
   })
 }
+/**
+ * Function in charge to send the correct embed message when a user uses the `remind` command
+ * If there's an active reminder in the server, we send the reminder details embed
+ * If there's none, we send the reminder instructions embed
+ * More information on the helpers.js file
+ * @param message - message data object
+ */
 const sendReminderInformation = (message) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.get(`SELECT * FROM Reminder WHERE guild_id = ${message.guild.id} AND enabled = ${true}`, (error, enabledReminder) => {

--- a/database/reminder-details-db.js
+++ b/database/reminder-details-db.js
@@ -6,7 +6,7 @@ const sqlite = require('sqlite3').verbose();
  * @param database - yagi database
  */
 const createReminderDetailsTable = (database) => {
-  database.run(`CREATE TABLE IF NOT EXISTS Reminder_Details(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, requested_by TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL, no_of_reactions INTEGER NOT NULL)`);
+  database.run(`CREATE TABLE IF NOT EXISTS ReminderDetails(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, requested_by TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL, no_of_reactions INTEGER NOT NULL)`);
 }
 /**
  * Adds new reminder details message to Reminder Details table
@@ -16,7 +16,7 @@ const createReminderDetailsTable = (database) => {
  */
 const insertNewReminderDetails = (message, user) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.run('INSERT INTO Reminder_Details(uuid, created_at, requested_by, channel_id, guild_id, no_of_reactions) VALUES ($uuid, $created_at, $requested_by, $channel_id, $guild_id, $no_of_reactions)', {
+  database.run('INSERT INTO ReminderDetails(uuid, created_at, requested_by, channel_id, guild_id, no_of_reactions) VALUES ($uuid, $created_at, $requested_by, $channel_id, $guild_id, $no_of_reactions)', {
     $uuid: message.id,
     $created_at: message.createdAt,
     $requested_by: user.id,
@@ -39,7 +39,7 @@ const cacheExistingReminderDetails = (guilds) => {
 
   guilds.forEach(guild => {
     guild.channels.cache.forEach(channel => {
-      database.each(`SELECT * FROM Reminder_Details WHERE channel_id = ${channel.id}`, async (error, detail) => {
+      database.each(`SELECT * FROM ReminderDetails WHERE channel_id = ${channel.id}`, async (error, detail) => {
         if(error){
           console.log(error);
         }
@@ -52,13 +52,13 @@ const cacheExistingReminderDetails = (guilds) => {
 }
 const updateReminderDetails = (reaction) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.get(`SELECT * FROM Reminder_Details WHERE uuid = "${reaction.message.id}"`, (error, detail) => {
+  database.get(`SELECT * FROM ReminderDetails WHERE uuid = "${reaction.message.id}"`, (error, detail) => {
     if(error){
       console.log(error);
     }
     if(detail && !reaction.me && reaction.emoji.identifier === "%F0%9F%90%90"){
       const newCount = reaction.count - 1;
-      database.run(`UPDATE Reminder_Details SET no_of_reactions = ${newCount} WHERE uuid = ${detail.uuid}`, error => {
+      database.run(`UPDATE ReminderDetails SET no_of_reactions = ${newCount} WHERE uuid = ${detail.uuid}`, error => {
         if(error){
           console.log(error);
         }

--- a/database/reminder-details-db.js
+++ b/database/reminder-details-db.js
@@ -15,7 +15,24 @@ const insertNewReminderDetails = (message, user) => {
     $no_of_reactions: 0
   })
 }
+const cacheExistingReminderDetails = (guilds, client) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+
+  guilds.forEach(guild => {
+    guild.channels.cache.forEach(channel => {
+      database.each(`SELECT * FROM Reminder_Details WHERE channel_id = ${channel.id}`, async (error, detail) => {
+        if(error){
+          console.log(error);
+        }
+        if(detail){
+          await channel.messages.fetch(detail.uuid);
+        }
+      })
+    })
+  })
+}
 module.exports = {
   createReminderDetailsTable,
-  insertNewReminderDetails
+  insertNewReminderDetails,
+  cacheExistingReminderDetails
 }

--- a/database/reminder-details-db.js
+++ b/database/reminder-details-db.js
@@ -1,0 +1,21 @@
+const sqlite = require('sqlite3').verbose();
+
+const createReminderDetailsTable = (database) => {
+  database.run(`CREATE TABLE IF NOT EXISTS Reminder_Details(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, requested_by TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL, no_of_reactions INTEGER NOT NULL)`);
+}
+
+const insertNewReminderDetails = (message, user) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.run('INSERT INTO Reminder_Details(uuid, created_at, requested_by, channel_id, guild_id, no_of_reactions) VALUES ($uuid, $created_at, $requested_by, $channel_id, $guild_id, $no_of_reactions)', {
+    $uuid: message.id,
+    $created_at: message.createdAt,
+    $requested_by: user.id,
+    $channel_id: message.channel.id,
+    $guild_id: message.guild.id,
+    $no_of_reactions: 0
+  })
+}
+module.exports = {
+  createReminderDetailsTable,
+  insertNewReminderDetails
+}

--- a/database/reminder-details-db.js
+++ b/database/reminder-details-db.js
@@ -34,7 +34,7 @@ const insertNewReminderDetails = (message, user) => {
  * @param guilds - guilds that yagi is in
  * @param client - yagi client
  */
-const cacheExistingReminderDetails = (guilds, client) => {
+const cacheExistingReminderDetails = (guilds) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
 
   guilds.forEach(guild => {
@@ -50,8 +50,25 @@ const cacheExistingReminderDetails = (guilds, client) => {
     })
   })
 }
+const updateReminderDetails = (reaction) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.get(`SELECT * FROM Reminder_Details WHERE uuid = "${reaction.message.id}"`, (error, detail) => {
+    if(error){
+      console.log(error);
+    }
+    if(detail && !reaction.me && reaction.emoji.identifier === "%F0%9F%90%90"){
+      const newCount = reaction.count - 1;
+      database.run(`UPDATE Reminder_Details SET no_of_reactions = ${newCount} WHERE uuid = ${detail.uuid}`, error => {
+        if(error){
+          console.log(error);
+        }
+      })
+    }
+  })
+}
 module.exports = {
   createReminderDetailsTable,
   insertNewReminderDetails,
-  cacheExistingReminderDetails
+  cacheExistingReminderDetails,
+  updateReminderDetails
 }

--- a/database/reminder-details-db.js
+++ b/database/reminder-details-db.js
@@ -1,9 +1,19 @@
 const sqlite = require('sqlite3').verbose();
-
+/**
+ * Creates Reminder Details table inside the Yagi Database
+ * Gets called in the client.once('ready') hook
+ * Primarily to keep track of the special message from yagi where users can react with to get the reminder role
+ * @param database - yagi database
+ */
 const createReminderDetailsTable = (database) => {
   database.run(`CREATE TABLE IF NOT EXISTS Reminder_Details(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, requested_by TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL, no_of_reactions INTEGER NOT NULL)`);
 }
-
+/**
+ * Adds new reminder details message to Reminder Details table
+ * Gets called only when sending the user the reminderDetails message
+ * @param message - message data object
+ * @param user - user who initially used command
+ */
 const insertNewReminderDetails = (message, user) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.run('INSERT INTO Reminder_Details(uuid, created_at, requested_by, channel_id, guild_id, no_of_reactions) VALUES ($uuid, $created_at, $requested_by, $channel_id, $guild_id, $no_of_reactions)', {
@@ -15,6 +25,15 @@ const insertNewReminderDetails = (message, user) => {
     $no_of_reactions: 0
   })
 }
+/**
+ * Function to cache existing reminder detail messages in discordjs cache
+ * This is important as the messageReaction event handlers only look out for cached messages
+ * This means that messages before yagi boots up will not be watched out for
+ * To go around this, this function iterates on every channel on each guild yagi is in and fetches the existing reminder detail messages from Discord
+ * This function is called in the client.once('ready') hook to cache all the messages in the beginning
+ * @param guilds - guilds that yagi is in
+ * @param client - yagi client
+ */
 const cacheExistingReminderDetails = (guilds, client) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
 

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -39,6 +39,11 @@ const cacheExistingReminderReactionMessages = (guilds) => {
   database.serialize(() => {
     //Adding the creation of reminder reaction table here to make sure it gets called first before caching messages
     createReminderReactionMessageTable(database);
+
+    /**
+     * Keeping this loop in the off chance discord ever implements adding of role on behalf of users
+     * Dream is to support multiple reaction messages but currently we are limited to just one
+     **/
     guilds.forEach(guild => {
       guild.channels.cache.forEach(channel => {
         database.each(`SELECT * FROM ReminderReactionMessage WHERE channel_id = ${channel.id}`, async (error, detail) => {

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -5,8 +5,8 @@ const sqlite = require('sqlite3').verbose();
  * Primarily to keep track of the special message from yagi where users can react with to get the reminder role
  * @param database - yagi database
  */
-const createReminderDetailsTable = (database) => {
-  database.run(`CREATE TABLE IF NOT EXISTS ReminderDetails(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, requested_by TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL, no_of_reactions INTEGER NOT NULL)`);
+const createReminderReactionMessageTable = (database) => {
+  database.run(`CREATE TABLE IF NOT EXISTS ReminderReactionMessage(uuid TEXT NOT NULL PRIMARY KEY, created_at DATE NOT NULL, requested_by TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL, no_of_reactions INTEGER NOT NULL)`);
 }
 /**
  * Adds new reminder details message to Reminder Details table
@@ -14,9 +14,9 @@ const createReminderDetailsTable = (database) => {
  * @param message - message data object
  * @param user - user who initially used command
  */
-const insertNewReminderDetails = (message, user) => {
+const insertNewReminderReactionMessage = (message, user) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.run('INSERT INTO ReminderDetails(uuid, created_at, requested_by, channel_id, guild_id, no_of_reactions) VALUES ($uuid, $created_at, $requested_by, $channel_id, $guild_id, $no_of_reactions)', {
+  database.run('INSERT INTO ReminderReactionMessage(uuid, created_at, requested_by, channel_id, guild_id, no_of_reactions) VALUES ($uuid, $created_at, $requested_by, $channel_id, $guild_id, $no_of_reactions)', {
     $uuid: message.id,
     $created_at: message.createdAt,
     $requested_by: user.id,
@@ -34,12 +34,12 @@ const insertNewReminderDetails = (message, user) => {
  * @param guilds - guilds that yagi is in
  * @param client - yagi client
  */
-const cacheExistingReminderDetails = (guilds) => {
+const cacheExistingReminderReactionMessages = (guilds) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
 
   guilds.forEach(guild => {
     guild.channels.cache.forEach(channel => {
-      database.each(`SELECT * FROM ReminderDetails WHERE channel_id = ${channel.id}`, async (error, detail) => {
+      database.each(`SELECT * FROM ReminderReactionMessage WHERE channel_id = ${channel.id}`, async (error, detail) => {
         if(error){
           console.log(error);
         }
@@ -50,15 +50,15 @@ const cacheExistingReminderDetails = (guilds) => {
     })
   })
 }
-const updateReminderDetails = (reaction) => {
+const updateReminderReactionMessage = (reaction) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.get(`SELECT * FROM ReminderDetails WHERE uuid = "${reaction.message.id}"`, (error, detail) => {
+  database.get(`SELECT * FROM ReminderReactionMessage WHERE uuid = "${reaction.message.id}"`, (error, detail) => {
     if(error){
       console.log(error);
     }
     if(detail && !reaction.me && reaction.emoji.identifier === "%F0%9F%90%90"){
       const newCount = reaction.count - 1;
-      database.run(`UPDATE ReminderDetails SET no_of_reactions = ${newCount} WHERE uuid = ${detail.uuid}`, error => {
+      database.run(`UPDATE ReminderReactionMessage SET no_of_reactions = ${newCount} WHERE uuid = ${detail.uuid}`, error => {
         if(error){
           console.log(error);
         }
@@ -67,8 +67,8 @@ const updateReminderDetails = (reaction) => {
   })
 }
 module.exports = {
-  createReminderDetailsTable,
-  insertNewReminderDetails,
-  cacheExistingReminderDetails,
-  updateReminderDetails
+  createReminderReactionMessageTable,
+  insertNewReminderReactionMessage,
+  cacheExistingReminderReactionMessages,
+  updateReminderReactionMessage
 }

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -53,6 +53,13 @@ const cacheExistingReminderReactionMessages = (guilds) => {
     })
   })
 }
+/**
+ * Function to update the reaction message
+ * Only updates the reaction count for now as I don't think there's anything else that's important
+ * Substracts 1 from the count taken from discord since yagi by default also reacts to it and discord counts it
+ * Additional checks to see if the reaction is :goat: and if it's not made by the bot so we only update the table when necessary
+ * @param {*} reaction 
+ */
 const updateReminderReactionMessage = (reaction) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.get(`SELECT * FROM ReminderReactionMessage WHERE uuid = "${reaction.message.id}"`, (error, detail) => {

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -36,16 +36,19 @@ const insertNewReminderReactionMessage = (message, user) => {
  */
 const cacheExistingReminderReactionMessages = (guilds) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-
-  guilds.forEach(guild => {
-    guild.channels.cache.forEach(channel => {
-      database.each(`SELECT * FROM ReminderReactionMessage WHERE channel_id = ${channel.id}`, async (error, detail) => {
-        if(error){
-          console.log(error);
-        }
-        if(detail){
-          await channel.messages.fetch(detail.uuid);
-        }
+  database.serialize(() => {
+    //Adding the creation of reminder reaction table here to make sure it gets called first before caching messages
+    createReminderReactionMessageTable(database);
+    guilds.forEach(guild => {
+      guild.channels.cache.forEach(channel => {
+        database.each(`SELECT * FROM ReminderReactionMessage WHERE channel_id = ${channel.id}`, async (error, detail) => {
+          if(error){
+            console.log(error);
+          }
+          if(detail){
+            await channel.messages.fetch(detail.uuid);
+          }
+        })
       })
     })
   })

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -1,0 +1,53 @@
+const { reactToAllReminderDetails } = require('./reminder-details-db');
+
+const sqlite = require('sqlite3').verbose();
+
+const createReminderUserTable = (database) => {
+  database.run('CREATE TABLE IF NOT EXISTS ReminderUser(uuid TEXT NOT NULL PRIMARY KEY, reacted_at DATE NOT NULL, guild_id TEXT NOT NULL, channel_id TEXT NOT NULL, reminder_detail_id TEXT NOT NULL)');
+}
+
+const reactToMessage = (reaction, user) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.get(`SELECT * FROM ReminderUser WHERE uuid = "${user.id}"`, (error, reminderUser) => {
+    if(error){
+      console.log(error);
+    }
+    database.get(`SELECT * FROM ReminderDetails WHERE uuid = "${reaction.message.id}"`, (error, reminderDetail) => {
+      if(error){
+        console.log(error);
+      }
+      if(reminderDetail && !reminderUser && !reaction.me && reaction.emoji.identifier === "%F0%9F%90%90"){
+        insertNewReminderUser(reaction, user);
+      }
+    })
+  })
+}
+const insertNewReminderUser = (reaction, user) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.serialize(() => {
+    database.run(`INSERT INTO ReminderUser(uuid, reacted_at, guild_id, channel_id, reminder_detail_id) VALUES ($uuid, $reacted_at, $guild_id, $channel_id, $reminder_detail_id)`, {
+      $uuid: user.id,
+      $reacted_at: new Date(),
+      $guild_id: reaction.message.guild.id,
+      $channel_id: reaction.message.channel.id,
+      $reminder_detail_id: reaction.message.id
+    }, error => {
+      if(error){
+        console.log(error);
+      }
+    })
+  })
+}
+const removeReminderUser = (user) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.run(`DELETE FROM ReminderUser WHERE uuid = ${user.id}`, error => {
+    if(error){
+      console.log(error);
+    }
+  })
+}
+module.exports = {
+  createReminderUserTable,
+  reactToMessage,
+  removeReminderUser
+}

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -1,4 +1,4 @@
-const { reactToAllReminderDetails } = require('./reminder-details-db');
+const { reactToAllReminderDetails } = require('./reminder-reaction-message-db');
 
 const sqlite = require('sqlite3').verbose();
 

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -70,6 +70,15 @@ const removeReminderUser = (reaction, user) => {
     setReminderRoleToUser(reaction, user, 'remove');
   })
 }
+/**
+ * Function to add the reminder role to a user or remove it
+ * Gets called after adding the reminder user to our database
+ * To be able to properly set the role, we need to fetch the guild member object of the user first
+ * Then we can use it to add the reminder role to it
+ * @param reaction - reaction data object
+ * @param user - user who made the reaction
+ * @param type - whether or not it's adding or removing a reaction
+ */
 const setReminderRoleToUser = (reaction, user, type) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.get(`SELECT * FROM Reminder WHERE guild_id = "${reaction.message.guild.id}" AND enabled = ${true}`, (error, reminder) => {

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -1,9 +1,22 @@
 const sqlite = require('sqlite3').verbose();
 
+/**
+ * Creates Reminder User table inside the Yagi Database
+ * Gets called in the client.once("ready") hook
+ * Primarily used to keep track of users who've reacted to the reaction message
+ * @param database - yagi database
+ */
 const createReminderUserTable = (database) => {
   database.run('CREATE TABLE IF NOT EXISTS ReminderUser(uuid TEXT NOT NULL PRIMARY KEY, reacted_at DATE NOT NULL, guild_id TEXT NOT NULL, channel_id TEXT NOT NULL, reminder_detail_id TEXT NOT NULL)');
 }
-
+/**
+ * Function in charge on what to do when a user reacts to a message
+ * First checks if the user who reacted exists in our database
+ * If they aren't, we then check if the message they reacted to is a reminder reaction message before calling the insertNewReminderUser to add it to our table
+ * Additional check to also see if the reaction was made by the bot or if the reaction is :goat: so we only update when necessary
+ * @param reaction - reaction data object
+ * @param user - user who made the reaction
+ */
 const reactToMessage = (reaction, user) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.get(`SELECT * FROM ReminderUser WHERE uuid = "${user.id}"`, (error, reminderUser) => {
@@ -20,6 +33,13 @@ const reactToMessage = (reaction, user) => {
     })
   })
 }
+/**
+ * Adds new user to Reminder User table
+ * Called after the user reacts to a reaction message with :goat:
+ * Only need an Insert and not have an Update function as we don't really care about storing users in our database if they unreact to the message
+ * @param reaction - reaction data object
+ * @param user - user who made the reaction
+ */
 const insertNewReminderUser = (reaction, user) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.serialize(() => {
@@ -36,6 +56,10 @@ const insertNewReminderUser = (reaction, user) => {
     })
   })
 }
+/**
+ * Deletes the user from Reminder User Table
+ * @param user - user who unreacted
+ */
 const removeReminderUser = (user) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.run(`DELETE FROM ReminderUser WHERE uuid = ${user.id}`, error => {

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -1,5 +1,3 @@
-const { reactToAllReminderDetails } = require('./reminder-reaction-message-db');
-
 const sqlite = require('sqlite3').verbose();
 
 const createReminderUserTable = (database) => {
@@ -12,7 +10,7 @@ const reactToMessage = (reaction, user) => {
     if(error){
       console.log(error);
     }
-    database.get(`SELECT * FROM ReminderDetails WHERE uuid = "${reaction.message.id}"`, (error, reminderDetail) => {
+    database.get(`SELECT * FROM ReminderReactionMessage WHERE uuid = "${reaction.message.id}"`, (error, reminderDetail) => {
       if(error){
         console.log(error);
       }
@@ -46,6 +44,7 @@ const removeReminderUser = (user) => {
     }
   })
 }
+
 module.exports = {
   createReminderUserTable,
   reactToMessage,

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -1,5 +1,6 @@
 const sqlite = require('sqlite3').verbose();
-const { generateUUID } = require('../helpers');
+const { generateUUID, reminderReactionMessage } = require('../helpers');
+const { insertNewReminderReactionMessage } = require('./reminder-reaction-message-db');
 /**
  * Creates Role table inside the Yagi Database
  * Gets called in the client.once("ready") hook
@@ -101,10 +102,10 @@ const updateRole = (role) => {
  * @param guild - current guild object; needed to create a role
  * @param reminderID - reminder id
  */
-const createReminderRole = async (guild, reminderID) => {
+const createReminderRole = async (message, reminder) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   try {
-    const reminderRole = await guild.roles.create({
+    const reminderRole = await message.guild.roles.create({
       data: {
         name: 'Goat Hunters',
         color: '#68d5e9'
@@ -112,22 +113,26 @@ const createReminderRole = async (guild, reminderID) => {
       reason: 'Role to be used by Yagi for automated reminders for Vulture Vale/Blizzard Berg World Boss'
     })
     database.serialize(() => {
-      database.get(`SELECT * FROM Role WHERE role_id = ${reminderRole.id} AND guild_id = ${reminderRole.guild.id}`, (error, row) => {
+      database.get(`SELECT * FROM Role WHERE role_id = ${reminderRole.id} AND guild_id = ${reminderRole.guild.id}`, (error, role) => {
         if(error){
           console.log(error);
         }
-        if(row){
+        if(role){
           //Update reminder role with relevant data
-          database.run(`UPDATE Role SET reminder_id = "${reminderID}", used_for_reminder = ${true} WHERE uuid = "${row.uuid}"`, err => {
+          database.run(`UPDATE Role SET reminder_id = "${reminder.uuid}", used_for_reminder = ${true} WHERE uuid = "${role.uuid}"`, err => {
             if(err){
               console.log(err);
             }
           })
           //Update Reminder with created role
-          database.run(`UPDATE Reminder SET role_uuid = "${row.uuid}" where uuid = "${reminderID}"`, err => {
+          database.run(`UPDATE Reminder SET role_uuid = "${role.uuid}" where uuid = "${reminder.uuid}"`, async err => {
             if(err){
               console.log(err);
             }
+            const embed = reminderReactionMessage(reminder.channel_id, role.role_id);
+            const messageDetail = await message.channel.send({ embed })
+            await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
+            insertNewReminderReactionMessage(messageDetail, message.author);
           })
         }
       })

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -138,7 +138,7 @@ const createReminderRole = async (message, reminder) => {
             const embed = reminderReactionMessage(reminder.channel_id, role.role_id);
             const messageDetail = await message.channel.send({ embed })
             await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
-            insertNewReminderReactionMessage(messageDetail, message.author);
+            insertNewReminderReactionMessage(messageDetail, message.author, reminder);
           })
         }
       })

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -99,8 +99,8 @@ const updateRole = (role) => {
  * Create role to be used by yagi for reminders
  * Uses update instead of inserting new row in table as the roleCreate event when creating a the new role
  * To prevent duplicate roles from being inserted into the table, we update the created role from the insertNewRole function with the relevant data
- * @param guild - current guild object; needed to create a role
- * @param reminderID - reminder id
+ * @param message - message data object. Used to get current guild object needed to create a role
+ * @param reminder - reminder to be linked with role
  */
 const createReminderRole = async (message, reminder) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
@@ -129,6 +129,12 @@ const createReminderRole = async (message, reminder) => {
             if(err){
               console.log(err);
             }
+            /**
+             * We send our reminder reaction message only after a reminder gets enabled
+             * This is to collect reactions that yagi will use to set the reminder role
+             * Yagi reacts to the message by default after sending it so users won't have to find the reaction
+             * * By design and discord's api limitation, there will only be one reminder reaction message per server. 
+             */
             const embed = reminderReactionMessage(reminder.channel_id, role.role_id);
             const messageDetail = await message.channel.send({ embed })
             await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:

--- a/helpers.js
+++ b/helpers.js
@@ -356,7 +356,7 @@ const reminderDetails = (channel, role) => {
   }
   return embed;
 }
-const reminderReactionMessage = () => {
+const reminderReactionMessage = (channel, role) => {
   const embed = {
     color: 32896,
     description: "To get notified, react to this message with :goat: and you will get the role!\n\n*Note that by removing the reaction you will lose the role*",
@@ -394,5 +394,6 @@ module.exports = {
   disableReminderEmbed,
   enableReminderEmbed,
   reminderInstructions,
-  reminderDetails
+  reminderDetails,
+  reminderReactionMessage
 }

--- a/helpers.js
+++ b/helpers.js
@@ -329,8 +329,37 @@ const reminderInstructions = () => {
 //----------
 const reminderDetails = (channel, role) => {
   const embed = {
+    title: "Reminder Details",
     color: 32896,
-    description: "Below are the details used for reminders. To get notified, react to this message with :goat: and you will get the role!\n\n*Note that by removing the reaction you will lose the role*",
+    description: "To get notified, react to the linked message below!",
+    thumbnail: {
+      url:
+        'https://cdn.discordapp.com/attachments/248430185463021569/864309441821802557/goat-timer_logo_dark2_reminder.png'
+    },
+    fields: [
+      {
+        name: "Active Channel",
+        value: `<#${channel}>`,
+        inline: true
+      },
+      {
+        name: "Reminder Role",
+        value: `<@&${role}>`,
+        inline: true
+      },
+      {
+        name: "Reaction Message",
+        value: 'Click me! (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧',
+
+      }
+    ]
+  }
+  return embed;
+}
+const reminderReactionMessage = () => {
+  const embed = {
+    color: 32896,
+    description: "To get notified, react to this message with :goat: and you will get the role!\n\n*Note that by removing the reaction you will lose the role*",
     thumbnail: {
       url:
         'https://cdn.discordapp.com/attachments/248430185463021569/864309441821802557/goat-timer_logo_dark2_reminder.png'

--- a/helpers.js
+++ b/helpers.js
@@ -327,7 +327,16 @@ const reminderInstructions = () => {
   return embed;
 }
 //----------
-const reminderDetails = (channel, role) => {
+/**
+ * Embed design used to display the details of the active reminder in the server
+ * Active Channel - channel where the reminder is enabled
+ * Reminder Role - role that yagi uses to ping users
+ * Reaction Message - a link to the message where users can react to get reminder role
+ * @param channel - channelId 
+ * @param role - roleId
+ * @param message - messageId
+ */
+const reminderDetails = (channel, role, message) => {
   const embed = {
     title: "Reminder Details",
     color: 32896,
@@ -356,9 +365,17 @@ const reminderDetails = (channel, role) => {
   }
   return embed;
 }
+//----------
+/**
+ * Embed design used to inform users how to get pinged by Yagi and acts as a collector for reactions
+ * Active Channel - channel where the reminder is enabled
+ * Reminder Role - role that yagi uses to ping users
+ * @param channel - channelId 
+ * @param role - roleId
+ */
 const reminderReactionMessage = (channel, role) => {
   const embed = {
-    color: 32896,
+    color: 16761651,
     description: "To get notified, react to this message with :goat: and you will get the role!\n\n*Note that by removing the reaction you will lose the role*",
     thumbnail: {
       url:

--- a/helpers.js
+++ b/helpers.js
@@ -358,7 +358,7 @@ const reminderDetails = (channel, role, message) => {
       },
       {
         name: "Reaction Message",
-        value: 'Click me! (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧',
+        value: `[Click me! (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧](${message})`,
 
       }
     ]

--- a/yagi.js
+++ b/yagi.js
@@ -9,6 +9,7 @@ const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildM
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
 const { createReminderTable } = require('./database/reminder-db.js');
+const { createReminderDetailsTable } = require('./database/reminder-details-db.js');
 const { sendMixpanelEvent } = require('./analytics');
 
 const activitylist = [
@@ -70,6 +71,7 @@ yagi.once('ready', () => {
     createChannelTable(yagiDatabase, yagi.channels.cache, yagi);
     createRoleTable(yagiDatabase, yagi.guilds.cache);
     createReminderTable(yagiDatabase);
+    createReminderDetailsTable(yagiDatabase);
     /**
      * Changes Yagi's activity every 2 minutes on random
      * Starts on the first index of the activityList array and then sets to a different one after
@@ -197,6 +199,7 @@ yagi.on('roleUpdate', (_, newRole) => {
  * Event handlers for when a cached message gets reactions
  */
 yagi.on('messageReactionAdd', (reaction, user) => {
+  
   console.log(user.username);
   console.log(reaction.emoji.identifier);
   console.log(reaction.emoji.name);

--- a/yagi.js
+++ b/yagi.js
@@ -9,7 +9,7 @@ const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildM
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
 const { createReminderTable } = require('./database/reminder-db.js');
-const { createReminderDetailsTable } = require('./database/reminder-details-db.js');
+const { createReminderDetailsTable, cacheExistingReminderDetails } = require('./database/reminder-details-db.js');
 const { sendMixpanelEvent } = require('./analytics');
 
 const activitylist = [
@@ -59,7 +59,6 @@ yagi.once('ready', () => {
         })
       })
     })
-
     console.log(`Number of guilds: ${yagi.guilds.cache.size}`);
     /**
      * Initialise Database and its tables
@@ -72,6 +71,7 @@ yagi.once('ready', () => {
     createRoleTable(yagiDatabase, yagi.guilds.cache);
     createReminderTable(yagiDatabase);
     createReminderDetailsTable(yagiDatabase);
+    cacheExistingReminderDetails(yagi.guilds.cache, yagi);
     /**
      * Changes Yagi's activity every 2 minutes on random
      * Starts on the first index of the activityList array and then sets to a different one after
@@ -199,7 +199,6 @@ yagi.on('roleUpdate', (_, newRole) => {
  * Event handlers for when a cached message gets reactions
  */
 yagi.on('messageReactionAdd', (reaction, user) => {
-  
   console.log(user.username);
   console.log(reaction.emoji.identifier);
   console.log(reaction.emoji.name);

--- a/yagi.js
+++ b/yagi.js
@@ -8,8 +8,8 @@ const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment } = requ
 const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildMemberCount } = require('./database/guild-db.js');
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
-const { createReminderTable } = require('./database/reminder-db.js');
-const { createReminderDetailsTable, cacheExistingReminderDetails, updateReminderDetails } = require('./database/reminder-details-db.js');
+const { createReminderTable } = require('./database/reminder-db');
+const { createReminderReactionMessageTable, cacheExistingReminderReactionMessages, updateReminderReactionMessage} = require('./database/reminder-reaction-message-db.js');
 const { createReminderUserTable, reactToMessage, removeReminderUser } = require('./database/reminder-user-db.js');
 const { sendMixpanelEvent } = require('./analytics');
 
@@ -71,8 +71,8 @@ yagi.once('ready', () => {
     createChannelTable(yagiDatabase, yagi.channels.cache, yagi);
     createRoleTable(yagiDatabase, yagi.guilds.cache);
     createReminderTable(yagiDatabase);
-    createReminderDetailsTable(yagiDatabase);
-    cacheExistingReminderDetails(yagi.guilds.cache);
+    createReminderReactionMessageTable(yagiDatabase)
+    cacheExistingReminderReactionMessages(yagi.guilds.cache);
     createReminderUserTable(yagiDatabase);
     /**
      * Changes Yagi's activity every 2 minutes on random
@@ -201,11 +201,11 @@ yagi.on('roleUpdate', (_, newRole) => {
  * Event handlers for when a cached message gets reactions
  */
 yagi.on('messageReactionAdd', (reaction, user) => {
-  updateReminderDetails(reaction);
+  updateReminderReactionMessage(reaction);
   reactToMessage(reaction, user);
 })
 yagi.on('messageReactionRemove', (reaction, user) => {
-  updateReminderDetails(reaction);
+  updateReminderReactionMessage(reaction);
   removeReminderUser(user);
 })
 //------

--- a/yagi.js
+++ b/yagi.js
@@ -71,8 +71,7 @@ yagi.once('ready', () => {
     createChannelTable(yagiDatabase, yagi.channels.cache, yagi);
     createRoleTable(yagiDatabase, yagi.guilds.cache);
     createReminderTable(yagiDatabase);
-    createReminderReactionMessageTable(yagiDatabase)
-    cacheExistingReminderReactionMessages(yagi.guilds.cache);
+    cacheExistingReminderReactionMessages(yagi.guilds.cache); //creates reminder reaction table first -> cache messages after
     createReminderUserTable(yagiDatabase);
     /**
      * Changes Yagi's activity every 2 minutes on random

--- a/yagi.js
+++ b/yagi.js
@@ -9,7 +9,7 @@ const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildM
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
 const { createReminderTable } = require('./database/reminder-db');
-const { createReminderReactionMessageTable, cacheExistingReminderReactionMessages, updateReminderReactionMessage} = require('./database/reminder-reaction-message-db.js');
+const { cacheExistingReminderReactionMessages, updateReminderReactionMessage} = require('./database/reminder-reaction-message-db.js');
 const { createReminderUserTable, reactToMessage, removeReminderUser } = require('./database/reminder-user-db.js');
 const { sendMixpanelEvent } = require('./analytics');
 
@@ -207,13 +207,13 @@ yagi.on('roleUpdate', (_, newRole) => {
  * messageReactionRemove - called when a user unreacts to a message
  * More information about each function in their relevant database files
  */
-yagi.on('messageReactionAdd', (reaction, user) => {
+yagi.on('messageReactionAdd', async (reaction, user) => {
   updateReminderReactionMessage(reaction);
   reactToMessage(reaction, user);
 })
 yagi.on('messageReactionRemove', (reaction, user) => {
   updateReminderReactionMessage(reaction);
-  removeReminderUser(user);
+  removeReminderUser(reaction, user);
 })
 //------
 /**

--- a/yagi.js
+++ b/yagi.js
@@ -194,6 +194,16 @@ yagi.on('roleUpdate', (_, newRole) => {
 })
 //------
 /**
+ * Event handlers for when a cached message gets reactions
+ */
+yagi.on('messageReactionAdd', (reaction, user) => {
+  console.log(user.username);
+  console.log(reaction.emoji.identifier);
+  console.log(reaction.emoji.name);
+  console.log(reaction.me);
+})
+//------
+/**
  * Event handler for when a message is sent in a channel that yagi is in
  */
 yagi.on('message', async (message) => {

--- a/yagi.js
+++ b/yagi.js
@@ -9,7 +9,7 @@ const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildM
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
 const { createReminderTable } = require('./database/reminder-db.js');
-const { createReminderDetailsTable, cacheExistingReminderDetails } = require('./database/reminder-details-db.js');
+const { createReminderDetailsTable, cacheExistingReminderDetails, updateReminderDetails } = require('./database/reminder-details-db.js');
 const { sendMixpanelEvent } = require('./analytics');
 
 const activitylist = [
@@ -71,7 +71,7 @@ yagi.once('ready', () => {
     createRoleTable(yagiDatabase, yagi.guilds.cache);
     createReminderTable(yagiDatabase);
     createReminderDetailsTable(yagiDatabase);
-    cacheExistingReminderDetails(yagi.guilds.cache, yagi);
+    cacheExistingReminderDetails(yagi.guilds.cache);
     /**
      * Changes Yagi's activity every 2 minutes on random
      * Starts on the first index of the activityList array and then sets to a different one after
@@ -199,10 +199,10 @@ yagi.on('roleUpdate', (_, newRole) => {
  * Event handlers for when a cached message gets reactions
  */
 yagi.on('messageReactionAdd', (reaction, user) => {
-  console.log(user.username);
-  console.log(reaction.emoji.identifier);
-  console.log(reaction.emoji.name);
-  console.log(reaction.me);
+  updateReminderDetails(reaction);
+})
+yagi.on('messageReactionRemove', (reaction, user) => {
+  updateReminderDetails(reaction);
 })
 //------
 /**

--- a/yagi.js
+++ b/yagi.js
@@ -92,6 +92,7 @@ yagi.once('ready', () => {
  * channelCreate - called when new channel is created in a server yagi is in
  * channelDelete - called when channel is deleted in a server yagi is in
  * channelUpdate - called when updating details of a channel
+ * More information about each function in their relevant database files
  */
 yagi.on('channelCreate', (channel) => {
   try {
@@ -123,6 +124,9 @@ yagi.on('channelUpdate', (_, newChannel) => {
  * guildCreate - called when yagi is invited to a server
  * guildDelete - called when yagi is kicked from server
  * guildUpdate - called when updating details (e.g name change) in server yagi is in
+ * guildMemberAdd - called when a user gets invited to a server
+ * guildMemberRemove - called when a user leaves a server
+ * More information about each function in their relevant database files
  */
 yagi.on('guildCreate', (guild) => {
   try {
@@ -172,6 +176,7 @@ yagi.on('guildMemberRemove', (member) => {
  * roleCreate - called when a role is created in a server
  * roleDelete - called when a role is deleted in a server
  * roleUpdate - called when updating details (e.g. name change, color change) in a server
+ * More information about each function in their relevant database files
  */
 yagi.on('roleCreate', (role) => {
   try {
@@ -198,6 +203,9 @@ yagi.on('roleUpdate', (_, newRole) => {
 //------
 /**
  * Event handlers for when a cached message gets reactions
+ * messageReactionAdd - called when a user reacts to a message
+ * messageReactionRemove - called when a user unreacts to a message
+ * More information about each function in their relevant database files
  */
 yagi.on('messageReactionAdd', (reaction, user) => {
   updateReminderReactionMessage(reaction);

--- a/yagi.js
+++ b/yagi.js
@@ -10,6 +10,7 @@ const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, 
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
 const { createReminderTable } = require('./database/reminder-db.js');
 const { createReminderDetailsTable, cacheExistingReminderDetails, updateReminderDetails } = require('./database/reminder-details-db.js');
+const { createReminderUserTable, reactToMessage, removeReminderUser } = require('./database/reminder-user-db.js');
 const { sendMixpanelEvent } = require('./analytics');
 
 const activitylist = [
@@ -72,6 +73,7 @@ yagi.once('ready', () => {
     createReminderTable(yagiDatabase);
     createReminderDetailsTable(yagiDatabase);
     cacheExistingReminderDetails(yagi.guilds.cache);
+    createReminderUserTable(yagiDatabase);
     /**
      * Changes Yagi's activity every 2 minutes on random
      * Starts on the first index of the activityList array and then sets to a different one after
@@ -200,9 +202,11 @@ yagi.on('roleUpdate', (_, newRole) => {
  */
 yagi.on('messageReactionAdd', (reaction, user) => {
   updateReminderDetails(reaction);
+  reactToMessage(reaction, user);
 })
 yagi.on('messageReactionRemove', (reaction, user) => {
   updateReminderDetails(reaction);
+  removeReminderUser(user);
 })
 //------
 /**


### PR DESCRIPTION
#### Context
Gosh I didn't realise how complicated it would get. I also had to veto the initial design of reacting to reminder roles as discord api is still limited; they don't allow bots to react on a user's behalf nor can move specific messages around. This blew my original idea of having multiple reaction messages with shared total of reactions and having to downgrade to just one and having to link to the original reaction message when a user requests for the details

At least we're getting there slowly, just the actual reminding code left along with fleshing out all the database interactions and we're ready for v2.5

![image](https://user-images.githubusercontent.com/42207245/125724972-5c677928-b96d-40a8-b265-dc8d98e0b88d.png)
![image](https://user-images.githubusercontent.com/42207245/125724994-79a5bd62-ff3b-4008-9053-fb88cc4d261b.png)

![image](https://user-images.githubusercontent.com/42207245/125724987-7004a6f7-6a18-4521-be37-64bc685ba5c4.png)

#### Change
- React to message immediately after sending reaction message
- Create reminder reaction message and reminder users table
- Cache existing reminder reaction messages when booting up
- Update reminder details and reminder reaction designs
- Add/remove role when reacting/unreacting to reminder reaction

#### Release Notes
Add a way for users to get reminder role by reacting to a message