### PR TITLE
Reminder interactions

### DIFF
--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -15,7 +15,7 @@ module.exports = {
     if(arguments){
       switch (arguments) {
         case 'enable':
-          return isAdmin ? enableReminder(message) : message.channel.send('Reminders can only be enabled by an admin');
+          return isAdmin ? enableReminder(message, yagi) : message.channel.send('Reminders can only be enabled by an admin');
         case 'disable':
           return isAdmin ? disableReminder(message) : message.channel.send('Reminders can only be disabled by an admin');
         default:

--- a/commands/timer/goats.js
+++ b/commands/timer/goats.js
@@ -160,7 +160,7 @@ const generateEmbed = function generateWorldBossEmbedToSend(worldBossData) {
   const spawnDesc = `Spawn: ${grvAcnt}${worldBossData.location.toLowerCase()}, ${
     validateSpawn(worldBossData, getServerTime()).nextSpawn
   }${grvAcnt}`;
-  const spawnFooter = validateSpawn(worldBossData, getServerTime()).accurate ? '' : `**Note that sheet data isn't up to date, timer might be a couple of minutes off`;
+  const spawnFooter = validateSpawn(worldBossData, getServerTime()).accurate ? '' : `**Note that sheet data isn't up to date, timer accuracy might be off`;
   /** 
    * This is far easier to get countdown but it isn't as reliable and accurate
    * I'll just leave it here for reference

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -248,7 +248,7 @@ const startReminders = (client) => {
 
         database.get(`SELECT * FROM Timer WHERE rowid = ${1}`, (error, timer) => {
           const reminderTimeout = setTimeout(() => {
-            sendReminderTimerEmbed(reminderChannel, role.role_id, timer);
+            const reminderTimerMessage = sendReminderTimerEmbed(reminderChannel, role.role_id, timer);
           }, 30000); //differenceInMilliseconds(timer.next_spawn, getServerTime()) - 300000
 
           database.run(`UPDATE Reminder SET timer = ${reminderTimeout} WHERE uuid = "${reminder.uuid}"`, error => {

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,5 +1,5 @@
 const sqlite = require('sqlite3').verbose();
-const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails, reminderReactionMessage, sendReminderTimerEmbed, getServerTime } = require('../helpers');
+const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails, reminderReactionMessage, sendReminderTimerEmbed, getServerTime, editReminderTimerStatus } = require('../helpers');
 const { createReminderRole } = require('./role-db');
 const { insertNewReminderReactionMessage} = require('./reminder-reaction-message-db.js');
 const { differenceInMilliseconds } = require('date-fns');
@@ -247,12 +247,13 @@ const startReminders = (database, client) => {
 
         database.get(`SELECT * FROM Timer WHERE rowid = ${1}`, (error, timer) => {
           const timerCountdown = differenceInMilliseconds(timer.next_spawn, getServerTime());
+          //Only start timers if nextSpawn date is after current server time
           if(timerCountdown >= 0) {
             const reminderTimeout = setTimeout(async () => {
               const reminderTimerMessage = await sendReminderTimerEmbed(reminderChannel, role.role_id, timer);
               setTimeout(async () => {
-                await reminderTimerMessage.edit('World boss has started in v1. If you are late, ask in-game for the current channel spawn'); //Edit timer message to display that world boss has started
-                // await reminderTimerMessage.delete({ timeout: 15000}); //Delete timer message after a certain time as world boss has ended
+                await editReminderTimerStatus(reminderTimerMessage, role.role_id, timer);//Edit timer message to display that world boss has started
+                await reminderTimerMessage.delete({ timeout: 15000 }); //Delete timer message after a certain time as world boss has ended
               }, 30000); //600000 - Fired 10 minutes after timer message is sent; during when world boss has started
             }, 60000); //600000 - 10 minutes before world boss spawns 
   

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -247,9 +247,13 @@ const startReminders = (client) => {
         const reminderChannel = client.channels.cache.get(reminder.channel_id);
 
         database.get(`SELECT * FROM Timer WHERE rowid = ${1}`, (error, timer) => {
-          const reminderTimeout = setTimeout(() => {
-            const reminderTimerMessage = sendReminderTimerEmbed(reminderChannel, role.role_id, timer);
-          }, 30000); //differenceInMilliseconds(timer.next_spawn, getServerTime()) - 300000
+          const reminderTimeout = setTimeout(async () => {
+            const reminderTimerMessage = await sendReminderTimerEmbed(reminderChannel, role.role_id, timer);
+            setTimeout(async () => {
+              await reminderTimerMessage.edit('World boss has started in v1. If you are late, ask in-game for the current channel spawn'); //Edit timer message to display that world boss has started
+              await reminderTimerMessage.delete({ timeout: 15000}); //Delete timer message after a certain time as world boss has ended
+            }, 30000);
+          }, 60000); //differenceInMilliseconds(timer.next_spawn, getServerTime()) - 300000
 
           database.run(`UPDATE Reminder SET timer = ${reminderTimeout} WHERE uuid = "${reminder.uuid}"`, error => {
             if(error){

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -8,7 +8,7 @@ const { insertNewReminderReactionMessage } = require('./reminder-reaction-messag
  * @param guilds - guilds that yagi is in; using this as roles are nested inside the guild collection
  * @param client - yagi client
  */
-const createRoleTable = async (database, guilds, client) => {
+const createRoleTable = async (database, guilds) => {
   //Wrapped in a serialize to ensure that each method is called in order which its initialised
   database.serialize(() => {
     //Creates Role Table with the relevant columns if it does not exist
@@ -138,7 +138,7 @@ const createReminderRole = async (message, reminder) => {
             const embed = reminderReactionMessage(reminder.channel_id, role.role_id);
             const messageDetail = await message.channel.send({ embed })
             await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
-            insertNewReminderReactionMessage(messageDetail, message.author, reminder);
+            insertNewReminderReactionMessage(messageDetail, message.author, reminder);  
           })
         }
       })

--- a/database/timer-db.js
+++ b/database/timer-db.js
@@ -25,13 +25,13 @@ const createTimerTable = (database, worldBoss, client) => {
       //Check if there's an existing timer in our database
       if(timer){
         //Update the timer if it does
-        updateTimerData(worldBoss, timer);
+        updateTimerData(database, worldBoss, timer);
       } else {
         //Create a new timer if it doesn't
         insertNewTimer(database, worldBoss);
       }
     });
-    startReminders(client); //Start existing enabled reminders on their timer countdowns on initialisation
+    startReminders(database, client); //Start existing enabled reminders on their timer countdowns on initialisation
   })
 }
 /**
@@ -59,8 +59,7 @@ const insertNewTimer = (database, worldBoss) => {
  * @param {*} worldBoss - validated world boss data
  * @param {*} timer - existing timer in table
  */
-const updateTimerData = (worldBoss, timer) => {
-  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+const updateTimerData = (database, worldBoss, timer) => {
   database.run(`UPDATE Timer SET last_retrieved_at = ${Date.now()}, location = "${worldBoss.location}", next_spawn = "${worldBoss.nextSpawn}", projected_next_spawn = "${worldBoss.projectedNextSpawn}", accurate = ${worldBoss.accurate} WHERE uuid = "${timer.uuid}"`, error => {
     if(error){
       console.log(error);
@@ -88,12 +87,12 @@ const getCurrentTimerData = (client) => {
         const worldBossData = await getWorldBossData();
         
         const validatedWorldBossData = validateWorldBossData(worldBossData, serverTime);
-        updateTimerData(validatedWorldBossData, timer);
+        updateTimerData(database, validatedWorldBossData, timer);
         
         sendHealthLog(healthChannel, worldBossData, validatedWorldBossData);
       }
     })
-    startReminders(client);
+    startReminders(database, client);
   })
 }
 

--- a/database/timer-db.js
+++ b/database/timer-db.js
@@ -1,5 +1,5 @@
 const sqlite = require('sqlite3').verbose();
-const { generateUUID, getWorldBossData, getServerTime, validateWorldBossData } = require('../helpers');
+const { generateUUID, getWorldBossData, getServerTime, validateWorldBossData, sendHealthLog } = require('../helpers');
 const { startReminders } = require('./reminder-db');
 const { isBefore } = require('date-fns');
 
@@ -82,15 +82,15 @@ const getCurrentTimerData = (client) => {
         console.log(error)
       }
       const serverTime = getServerTime();
+      const healthChannel = client.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
   
       if(timer.accurate === 0 || isBefore(timer.next_spawn, serverTime) ){
         const worldBossData = await getWorldBossData();
         
         const validatedWorldBossData = validateWorldBossData(worldBossData, serverTime);
         updateTimerData(validatedWorldBossData, timer);
-  
-        const healthChannel = client.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
-        healthChannel.send('Pinged sheet and updated timer data'); //Currently only a text, might want to send more info
+        
+        sendHealthLog(healthChannel, worldBossData, validatedWorldBossData);
       }
     })
     startReminders(client);

--- a/helpers.js
+++ b/helpers.js
@@ -612,6 +612,37 @@ const sendReminderTimerEmbed = (channel, role, worldBoss) => {
   channel.send(`<@&${role}> Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
 }
 //----------
+const sendHealthLog = (channel, rawData, trueData) => {
+  const embed = {
+    title: 'Yagi | Health Log',
+    description: 'Requested data from sheet',
+    color: trueData.accurate ? 3066993 : 16776960,
+    thumbnail: {
+      url:
+        'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png'
+    },
+    fields: [
+      {
+        name: 'Server Time',
+        value: codeBlock(trueData.serverTime)
+      },
+      {
+        name: 'Sheet Data',
+        value: `• Next Spawn: ${codeBlock(rawData.nextSpawn)}\n• Countdown: ${codeBlock(rawData.countdown)}`
+      },
+      {
+        name: 'True Data',
+        value: `• Next Spawn: ${codeBlock(trueData.nextSpawn)}\n• Countdown: ${codeBlock(trueData.countdown)}`
+      },
+      {
+        name: 'Accurate',
+        value: trueData.accurate ? 'Yes' : 'No'
+      }
+    ]
+  }
+  channel.send({ embed });
+}
+//----------
 module.exports = {
   getServerTime,
   formatCountdown,
@@ -631,5 +662,6 @@ module.exports = {
   getWorldBossData,
   validateWorldBossData,
   codeBlock,
-  sendReminderTimerEmbed
+  sendReminderTimerEmbed,
+  sendHealthLog
 }

--- a/helpers.js
+++ b/helpers.js
@@ -661,7 +661,7 @@ const sendHealthLog = (channel, rawData, trueData) => {
       },
       {
         name: 'True Data',
-        value: `• Next Spawn: ${codeBlock(trueData.nextSpawn)}\n• Countdown: ${codeBlock(trueData.countdown)}`
+        value: `• Next Spawn: ${codeBlock(trueData.nextSpawn)}\n• Countdown: ${codeBlock(trueData.countdown)}\n• Projected: ${codeBlock(trueData.projectedNextSpawn)}`
       },
       {
         name: 'Accurate',

--- a/helpers.js
+++ b/helpers.js
@@ -578,21 +578,22 @@ const sendReminderTimerEmbed = (channel, role, worldBoss) => {
   const serverTimeDescription = `Server Time: ${codeBlock(format(serverTime, 'dddd, h:mm:ss A'))}`;
   const spawnText = `${worldBoss.location.toLowerCase()}, ${format(worldBoss.next_spawn, 'h:mm:ss A')}`;
   const spawnDescription = `Spawn: ${codeBlock(spawnText)}`;
-  const inaccurateText = `*Sheet data isn't up to date, timer accuracy might be off*`;
+  const inaccurateText = `**Note that sheet data isn't up to date, timer accuracy might be off`;
 
-  const spawnFooter = `This feature is currently in beta. If you have any feedback, feel free to leave it here!\nFor questions, suggestions and bug reports, make sure to join the support server!`
+  //Don't forget to add typeform and yagi's discord server invite
+  const spawnFooter = `*This feature is currently in beta. If you have any feedback, feel free to leave it [here](https://www.google.com/)! Or join the [support server](https://discord.gg/7nAYYDm) if you have any questions and want to keep up-to-date with yagi's development!*`
 
   const embed = {
     title: 'Olympus | World Boss',
-    description: `${serverTimeDescription}\n${spawnDescription}\n\n${worldBoss.accurate ? '' : inaccurateText}`,
+    description: `${serverTimeDescription}\n${spawnDescription}\n\n${spawnFooter}`,
     thumbnail: {
       url:
         'https://cdn.discordapp.com/attachments/248430185463021569/864309441821802557/goat-timer_logo_dark2_reminder.png'
     },
-    footer: {
-      text: spawnFooter
-    },
     color: 32896,
+    footer: {
+      text: worldBoss.accurate ? '' : inaccurateText
+    },
     fields: [
       {
         name: 'Location',

--- a/helpers.js
+++ b/helpers.js
@@ -614,6 +614,33 @@ const sendReminderTimerEmbed = (channel, role, worldBoss) => {
   return channel.send(`<@&${role}> Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
 }
 //----------
+const editReminderTimerStatus = (message, role, worldBoss) => {
+  const serverTime = getServerTime();
+  const serverTimeDescription = `Server Time: ${codeBlock(format(serverTime, 'dddd, h:mm:ss A'))}`;
+  const spawnText = `${worldBoss.location.toLowerCase()}, ${format(worldBoss.next_spawn, 'h:mm:ss A')}`;
+  const spawnDescription = `Spawn: ${codeBlock(spawnText)}`;
+ 
+  //Don't forget to add typeform and yagi's discord server invite
+  const spawnFooter = `*This feature is currently in beta. If you have any feedback, feel free to leave it [here](https://www.google.com/)! Or join the [support server](https://discord.gg/7nAYYDm) if you have any questions and want to keep up-to-date with yagi's development!*`
+
+  const embed = {
+    title: 'Olympus | World Boss',
+    description: `${serverTimeDescription}\n${spawnDescription}\n\n${spawnFooter}`,
+    thumbnail: {
+      url:
+        'https://cdn.discordapp.com/attachments/248430185463021569/864309441821802557/goat-timer_logo_dark2_reminder.png'
+    },
+    color: 32896,
+    fields: [
+      {
+        name: 'Status',
+        value: '```fix\n\n' + `World Boss has started in ${formatLocation(worldBoss.location)}. If you are late, ask in-game for current spawn channel.` + '```'
+      }
+    ]
+  }
+  return message.edit(`<@&${role}> Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
+}
+//----------
 const sendHealthLog = (channel, rawData, trueData) => {
   const embed = {
     title: 'Yagi | Health Log',
@@ -665,5 +692,6 @@ module.exports = {
   validateWorldBossData,
   codeBlock,
   sendReminderTimerEmbed,
+  editReminderTimerStatus,
   sendHealthLog
 }

--- a/helpers.js
+++ b/helpers.js
@@ -578,12 +578,13 @@ const sendReminderTimerEmbed = (channel, role, worldBoss) => {
   const serverTimeDescription = `Server Time: ${codeBlock(format(serverTime, 'dddd, h:mm:ss A'))}`;
   const spawnText = `${worldBoss.location.toLowerCase()}, ${format(worldBoss.next_spawn, 'h:mm:ss A')}`;
   const spawnDescription = `Spawn: ${codeBlock(spawnText)}`;
+  const inaccurateText = `*Sheet data isn't up to date, timer accuracy might be off*`;
 
   const spawnFooter = `This feature is currently in beta. If you have any feedback, feel free to leave it here!\nFor questions, suggestions and bug reports, make sure to join the support server!`
 
   const embed = {
     title: 'Olympus | World Boss',
-    description: `${serverTimeDescription}\n${spawnDescription}`,
+    description: `${serverTimeDescription}\n${spawnDescription}\n\n${worldBoss.accurate ? '' : inaccurateText}`,
     thumbnail: {
       url:
         'https://cdn.discordapp.com/attachments/248430185463021569/864309441821802557/goat-timer_logo_dark2_reminder.png'
@@ -609,7 +610,7 @@ const sendReminderTimerEmbed = (channel, role, worldBoss) => {
       }
     ]
   }
-  channel.send(`<@&${role}> Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
+  return channel.send(`<@&${role}> Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
 }
 //----------
 const sendHealthLog = (channel, rawData, trueData) => {

--- a/helpers.js
+++ b/helpers.js
@@ -569,10 +569,21 @@ const validateWorldBossData = (worldBoss, serverTime) => {
   }
 }
 //----------
+/**
+ * Function to create a text into a discord code block
+ * @param text - text to transform
+ */
 const codeBlock = (text) => {
   return "`" + text + "`";
 }
 //----------
+/**
+ * Function to send the timer embed for reminders
+ * Similar to the message in the goats command but added a paragraph about the feature being in beta
+ * @param channel - channel to send the message in
+ * @param role - role to ping
+ * @param worldBoss - validated world boss data\
+ */
 const sendReminderTimerEmbed = (channel, role, worldBoss) => {
   const serverTime = getServerTime();
   const serverTimeDescription = `Server Time: ${codeBlock(format(serverTime, 'dddd, h:mm:ss A'))}`;
@@ -614,6 +625,14 @@ const sendReminderTimerEmbed = (channel, role, worldBoss) => {
   return channel.send(`<@&${role}> Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
 }
 //----------
+/**
+ * Function to edit the message of above when world boss has started
+ * This is just to be aethestically pleasing and to be informative for players that are late that's wb has begun
+ * Also lays a foundation for the future if we want to be editing where the current spawn is located with v3
+ * @param message - message to edit
+ * @param role - role to ping
+ * @param worldBoss - validated world boss data
+ */
 const editReminderTimerStatus = (message, role, worldBoss) => {
   const serverTime = getServerTime();
   const serverTimeDescription = `Server Time: ${codeBlock(format(serverTime, 'dddd, h:mm:ss A'))}`;
@@ -641,6 +660,14 @@ const editReminderTimerStatus = (message, role, worldBoss) => {
   return message.edit(`<@&${role}> Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
 }
 //----------
+/**
+ * Function to send health status so that I can monitor how the timer and reminders are doing
+ * Currently in it's state it just returns the raw sheet data, the validated data and the current server time
+ * In the future, I'll probably add more stuff in here like server status, individual channel status, number of active reminders and so forth 
+ * @param channel - channel to send health logs in
+ * @param {*} rawData - data from olympus spreadsheet
+ * @param {*} trueData - validated world boss data
+ */
 const sendHealthLog = (channel, rawData, trueData) => {
   const embed = {
     title: 'Yagi | Health Log',

--- a/yagi.js
+++ b/yagi.js
@@ -99,7 +99,7 @@ yagi.once('ready', async () => {
      */
     setInterval(() => {
       getCurrentTimerData(yagi);
-    }, 120000, yagi) //1800000 - 30 minutes
+    }, 1800000, yagi) //1800000 - 30 minutes
     const healthChannel = yagi.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
     sendHealthLog(healthChannel, worldBossData, validatedWorldBossData);
   } catch(e){

--- a/yagi.js
+++ b/yagi.js
@@ -99,7 +99,7 @@ yagi.once('ready', async () => {
      */
     setInterval(() => {
       getCurrentTimerData(yagi);
-    }, 60000, yagi)
+    }, 1200000, yagi)
     const healthChannel = yagi.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
     sendHealthLog(healthChannel, worldBossData, validatedWorldBossData);
   } catch(e){

--- a/yagi.js
+++ b/yagi.js
@@ -13,7 +13,6 @@ const { cacheExistingReminderReactionMessages, updateReminderReactionMessage} = 
 const { createReminderUserTable, reactToMessage, removeReminderUser } = require('./database/reminder-user-db.js');
 const { createTimerTable, getCurrentTimerData } = require('./database/timer-db.js');
 const { sendMixpanelEvent } = require('./analytics');
-const { format } = require('date-fns');
 const activitylist = [
   'info | bot information',
   'ping me for prefix!',

--- a/yagi.js
+++ b/yagi.js
@@ -4,11 +4,11 @@ const commands = require('./commands');
 const yagi = new Discord.Client();
 const sqlite = require('sqlite3').verbose();
 const Mixpanel = require('mixpanel');
-const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment, getWorldBossData, getServerTime, validateWorldBossData } = require('./helpers');
+const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment, getWorldBossData, getServerTime, validateWorldBossData, sendHealthLog } = require('./helpers');
 const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildMemberCount } = require('./database/guild-db.js');
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
-const { createReminderTable, startReminders } = require('./database/reminder-db.js');
+const { createReminderTable } = require('./database/reminder-db.js');
 const { cacheExistingReminderReactionMessages, updateReminderReactionMessage} = require('./database/reminder-reaction-message-db.js');
 const { createReminderUserTable, reactToMessage, removeReminderUser } = require('./database/reminder-user-db.js');
 const { createTimerTable, getCurrentTimerData } = require('./database/timer-db.js');
@@ -98,9 +98,11 @@ yagi.once('ready', async () => {
      * However, we don't want to spam requests on the sheet so we'll only ping if our current timer data on our end is either innacurate or the next spawn date has already passed
      * For more documentation, see the timer-db file
      */
-    setInterval(async () => {
+    setInterval(() => {
       getCurrentTimerData(yagi);
-    }, 600000, yagi)
+    }, 60000, yagi)
+    const healthChannel = yagi.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
+    sendHealthLog(healthChannel, worldBossData, validatedWorldBossData);
   } catch(e){
     sendErrorLog(yagi, e);
   }

--- a/yagi.js
+++ b/yagi.js
@@ -99,7 +99,7 @@ yagi.once('ready', async () => {
      */
     setInterval(() => {
       getCurrentTimerData(yagi);
-    }, 1200000, yagi)
+    }, 120000, yagi) //1800000 - 30 minutes
     const healthChannel = yagi.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
     sendHealthLog(healthChannel, worldBossData, validatedWorldBossData);
   } catch(e){


### PR DESCRIPTION
#### Context
Losing my mind trying to make this work. Starting to lose motivation on this and questioning the reason of life but that's just probably me getting burnt out working on this everyday. I'll have to take a week off from coding projects and just learn japanese or something to cool down. Oh well, we're so close in finishing this so might as well push on. Just need to flesh out enabling reminders in between different channels and servers and adding a check for weekly maintenance times and we should be good to go

As for this pr, this just pretty much for aesthetic. Reminding is working as intended but just wanted to add an extra flair to it by editing the message when it's actually time for world boss and deleting the message once the hunt is over. Oh and also created a health log embed that displays raw data and true data to see if the timer is working fine.

![wb-reminder](https://user-images.githubusercontent.com/42207245/126317486-b05dbce5-4f78-43cb-883d-8420cd9ee385.gif)

#### Change
- Create health log embed
- Add inaccurate warning to reminder timer
- Add beta information
- Add edit and delete setTimeouts called after initial 10 minute timeout
- Add condition to not fire timeouts if countdown is less than 10 minutes

#### Considerations
Just get me to november

#### Release Notes
Add reminder interactions