### PR TITLE
Flesh out reminders initialisation

### DIFF
--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,7 +1,7 @@
 const sqlite = require('sqlite3').verbose();
 const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails, reminderReactionMessage } = require('../helpers');
 const { createReminderRole, startIndividualReminder } = require('./role-db');
-const { insertNewReminderReactionMessage} = require('./reminder-reaction-message-db.js');
+const { sendReminderReactionMessage } = require('./reminder-reaction-message-db.js');
 
 /**
  * Creates Reminder table inside the Yagi Database
@@ -63,17 +63,7 @@ const enableReminder = (message, client) => {
                   console.log(err);
                 }
                 if(role){
-                  /**
-                   * We send our reminder reaction message only after a reminder gets enabled
-                   * This is to collect reactions that yagi will use to set the reminder role
-                   * Yagi reacts to the message by default after sending it so users won't have to find the reaction
-                   * By design and discord's api limitation, there will only be one reminder reaction message per server. 
-                  */
-                  const embed = reminderReactionMessage(reminder.channel_id, role.role_id);
-                  const messageDetail = await message.channel.send({ embed })
-                  await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
-                  insertNewReminderReactionMessage(messageDetail, message.author, reminder);
-                  startIndividualReminder(database, reminder, role, client);
+                  sendReminderReactionMessage(database, message, client, reminder, role);
                 } else {
                   createReminderRole(message, reminder, client);
                 }
@@ -147,7 +137,7 @@ const enableReminder = (message, client) => {
               console.log(error);
             }
             startIndividualReminder(database, reminder, role, client);
-            //Reminder reaction should go here too
+            sendReminderReactionMessage(database, message, client, reminder, role);
           })
         })
       } else {

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -64,6 +64,7 @@ const enableReminder = (message, client) => {
                 }
                 if(role){
                   sendReminderReactionMessage(database, message, client, reminder, role);
+                  startIndividualReminder(database, reminder, role, client);
                 } else {
                   createReminderRole(message, reminder, client);
                 }

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -147,6 +147,7 @@ const enableReminder = (message, client) => {
               console.log(error);
             }
             startIndividualReminder(database, reminder, role, client);
+            //Reminder reaction should go here too
           })
         })
       } else {
@@ -189,6 +190,7 @@ const disableReminder = (message) => {
             if(err){
               console.log(err);
             }
+            stopReminder(database, reminder);
             message.channel.send({ embed });
           })
         }
@@ -256,12 +258,16 @@ const startReminders = (database, client) => {
     }
   })
 }
-
+const stopReminder = (database, reminder) => {
+  clearTimeout(reminder.timer);
+  database.run(`UPDATE Reminder SET timer = ${null} WHERE uuid = "${reminder.uuid}"`);
+}
 module.exports = {
   createReminderTable,
   insertNewReminder,
   enableReminder,
   disableReminder,
   sendReminderInformation,
-  startReminders
+  startReminders,
+  stopReminder
 }

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -90,13 +90,16 @@ const updateReminderReactionMessage = (reaction) => {
     }
   })
 }
+
 const sendReminderReactionMessage = (database, message, client, reminder, role) => {
   database.get(`SELECT * FROM ReminderReactionMessage WHERE guild_id = "${message.guild.id}"`, async (error, reactionMessage) => {
     if(reactionMessage){
       const reactionChannel = await client.channels.fetch(reactionMessage.channel_id); //Fetches channel data from discord
       const reactionMessageInChannel = await reactionChannel.messages.fetch(reactionMessage.uuid); //Fetches message data from discord
       const embed = reminderDetails(reminder.channel_id, role.role_id, reactionMessageInChannel.url);
-      message.channel.send({ embed });
+      database.run(`UPDATE Reminder SET reaction_message_id = "${reactionMessage.uuid}" WHERE uuid = "${reminder.uuid}"`, err => {
+        message.channel.send({ embed });
+      })
     } else {
       /**
        * We send our reminder reaction message only after a reminder gets enabled

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -72,7 +72,7 @@ const cacheExistingReminderReactionMessages = (guilds) => {
  * Only updates the reaction count for now as I don't think there's anything else that's important
  * Substracts 1 from the count taken from discord since yagi by default also reacts to it and discord counts it
  * Additional checks to see if the reaction is :goat: and if it's not made by the bot so we only update the table when necessary
- * @param {*} reaction 
+ * @param reaction - reaction data object
  */
 const updateReminderReactionMessage = (reaction) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
@@ -90,10 +90,24 @@ const updateReminderReactionMessage = (reaction) => {
     }
   })
 }
-
+/**
+ * Function to either send the reminder information or sending the reminder reaction message
+ * We need to check if there's already an existing reaction message due to discord's current api limitation of not being able to force user reactions and move specific messages
+ * Due to this, we need to only have one reaction message per server and just link to the message url in subsequent reminder enables
+ * @param database - yagi database
+ * @param message - message data object
+ * @param client - yagi client
+ * @param reminder - reminder that's enabled
+ * @param role - role being used to ping users
+ */
 const sendReminderReactionMessage = (database, message, client, reminder, role) => {
   database.get(`SELECT * FROM ReminderReactionMessage WHERE guild_id = "${message.guild.id}"`, async (error, reactionMessage) => {
     if(reactionMessage){
+      /**
+       * If a reaction message already exists in the current server, we don't want to create a new one
+       * Instead we show the reminder details instead so that users can be redirected to the original reaction message
+       * As new reminders have no reaction message by default, we update it with the reaction message in the end
+       */
       const reactionChannel = await client.channels.fetch(reactionMessage.channel_id); //Fetches channel data from discord
       const reactionMessageInChannel = await reactionChannel.messages.fetch(reactionMessage.uuid); //Fetches message data from discord
       const embed = reminderDetails(reminder.channel_id, role.role_id, reactionMessageInChannel.url);

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -1,4 +1,5 @@
 const sqlite = require('sqlite3').verbose();
+const { generateUUID } = require('../helpers');
 
 /**
  * Creates Reminder User table inside the Yagi Database
@@ -7,7 +8,7 @@ const sqlite = require('sqlite3').verbose();
  * @param database - yagi database
  */
 const createReminderUserTable = (database) => {
-  database.run('CREATE TABLE IF NOT EXISTS ReminderUser(uuid TEXT NOT NULL PRIMARY KEY, reacted_at DATE NOT NULL, guild_id TEXT NOT NULL, channel_id TEXT NOT NULL, reminder_reaction_message_id TEXT NOT NULL)');
+  database.run('CREATE TABLE IF NOT EXISTS ReminderUser(uuid TEXT NOT NULL PRIMARY KEY, user_id TEXT NOT NULL, reacted_at DATE NOT NULL, guild_id TEXT NOT NULL, channel_id TEXT NOT NULL, reminder_reaction_message_id TEXT NOT NULL)');
 }
 /**
  * Function in charge on what to do when a user reacts to a message
@@ -43,8 +44,9 @@ const reactToMessage = (reaction, user) => {
 const insertNewReminderUser = (reaction, user) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.serialize(() => {
-    database.run(`INSERT INTO ReminderUser(uuid, reacted_at, guild_id, channel_id, reminder_reaction_message_id) VALUES ($uuid, $reacted_at, $guild_id, $channel_id, $reminder_reaction_message_id)`, {
-      $uuid: user.id,
+    database.run(`INSERT INTO ReminderUser(uuid, user_id, reacted_at, guild_id, channel_id, reminder_reaction_message_id) VALUES ($uuid, $user_id, $reacted_at, $guild_id, $channel_id, $reminder_reaction_message_id)`, {
+      $uuid: generateUUID(),
+      $user_id: user.id,
       $reacted_at: new Date(),
       $guild_id: reaction.message.guild.id,
       $channel_id: reaction.message.channel.id,
@@ -63,7 +65,7 @@ const insertNewReminderUser = (reaction, user) => {
  */
 const removeReminderUser = (reaction, user) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.run(`DELETE FROM ReminderUser WHERE uuid = ${user.id}`, error => {
+  database.run(`DELETE FROM ReminderUser WHERE user_id = "${user.id}" AND guild_id = "${reaction.message.guild.id}"`, error => {
     if(error){
       console.log(error);
     }

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -154,15 +154,15 @@ const startIndividualReminder = (database, reminder, role, client) => {
     const timerCountdown = differenceInMilliseconds(timer.next_spawn, getServerTime());
     const reminderChannel = client.channels.cache.get(reminder.channel_id);
     //Only start timers if nextSpawn date is after current server time
-    if(timerCountdown >= 600000) {
+    if(timerCountdown >= 601000) {
       console.log('Restarting Reminders');
       const reminderTimeout = setTimeout(async () => {
         const reminderTimerMessage = await sendReminderTimerEmbed(reminderChannel, role.role_id, timer);
         setTimeout(async () => {
           await editReminderTimerStatus(reminderTimerMessage, role.role_id, timer);//Edit timer message to display that world boss has started
           await reminderTimerMessage.delete({ timeout: 1200000 }); //Delete timer message after 20 minutes as world boss has ended
-        }, 600000); //600000 - Fired 10 minutes after timer message is sent; during when world boss has started
-      }, timerCountdown - 4320000 - 600000); //600000 - 10 minutes before world boss spawns 
+        }, 601000); //600000 - Fired 10 minutes after timer message is sent; during when world boss has started
+      }, timerCountdown - 601000); //600000 - 10 minutes before world boss spawns 
 
       database.run(`UPDATE Reminder SET timer = ${reminderTimeout} WHERE uuid = "${reminder.uuid}"`, error => {
         if(error){

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -1,6 +1,6 @@
 const sqlite = require('sqlite3').verbose();
-const { generateUUID, reminderReactionMessage, sendReminderTimerEmbed, getServerTime, editReminderTimerStatus } = require('../helpers');
-const { insertNewReminderReactionMessage } = require('./reminder-reaction-message-db');
+const { generateUUID, sendReminderTimerEmbed, getServerTime, editReminderTimerStatus } = require('../helpers');
+const { sendReminderReactionMessage } = require('./reminder-reaction-message-db');
 const { differenceInMilliseconds } = require('date-fns');
 /**
  * Creates Role table inside the Yagi Database
@@ -130,16 +130,7 @@ const createReminderRole = async (message, reminder, client) => {
             if(err){
               console.log(err);
             }
-            /**
-             * We send our reminder reaction message only after a reminder gets enabled
-             * This is to collect reactions that yagi will use to set the reminder role
-             * Yagi reacts to the message by default after sending it so users won't have to find the reaction
-             * * By design and discord's api limitation, there will only be one reminder reaction message per server. 
-             */
-            const embed = reminderReactionMessage(reminder.channel_id, role.role_id);
-            const messageDetail = await message.channel.send({ embed })
-            await messageDetail.react('%F0%9F%90%90'); //Bot reacts to the message with :goat:
-            insertNewReminderReactionMessage(messageDetail, message.author, reminder);
+            sendReminderReactionMessage(database, message, client, reminder, role);
             startIndividualReminder(database, reminder, role, client);
           })
         }

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -1,7 +1,5 @@
 const sqlite = require('sqlite3').verbose();
-const { generateUUID, sendReminderTimerEmbed, getServerTime, editReminderTimerStatus } = require('../helpers');
-const { sendReminderReactionMessage } = require('./reminder-reaction-message-db');
-const { differenceInMilliseconds } = require('date-fns');
+const { generateUUID } = require('../helpers');
 /**
  * Creates Role table inside the Yagi Database
  * Gets called in the client.once("ready") hook
@@ -96,78 +94,9 @@ const updateRole = (role) => {
     }
   })
 }
-/**
- * Create role to be used by yagi for reminders
- * Uses update instead of inserting new row in table as the roleCreate event when creating a the new role
- * To prevent duplicate roles from being inserted into the table, we update the created role from the insertNewRole function with the relevant data
- * @param message - message data object. Used to get current guild object needed to create a role
- * @param reminder - reminder to be linked with role
- */
-const createReminderRole = async (message, reminder, client) => {
-  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  try {
-    const reminderRole = await message.guild.roles.create({
-      data: {
-        name: 'Goat Hunters',
-        color: '#68d5e9'
-      },
-      reason: 'Role to be used by Yagi for automated reminders for Vulture Vale/Blizzard Berg World Boss'
-    })
-    database.serialize(() => {
-      database.get(`SELECT * FROM Role WHERE role_id = ${reminderRole.id} AND guild_id = ${reminderRole.guild.id}`, (error, role) => {
-        if(error){
-          console.log(error);
-        }
-        if(role){
-          //Update reminder role with relevant data
-          database.run(`UPDATE Role SET reminder_id = "${reminder.uuid}", used_for_reminder = ${true} WHERE uuid = "${role.uuid}"`, err => {
-            if(err){
-              console.log(err);
-            }
-          })
-          //Update Reminder with created role
-          database.run(`UPDATE Reminder SET role_uuid = "${role.uuid}" where uuid = "${reminder.uuid}"`, async err => {
-            if(err){
-              console.log(err);
-            }
-            sendReminderReactionMessage(database, message, client, reminder, role);
-            startIndividualReminder(database, reminder, role, client);
-          })
-        }
-      })
-    })
-  } catch(e){
-    console.log(e);
-  }
-}
-const startIndividualReminder = (database, reminder, role, client) => {
-  database.get(`SELECT * FROM Timer WHERE rowid = ${1}`, (error, timer) => {
-    const timerCountdown = differenceInMilliseconds(timer.next_spawn, getServerTime());
-    const reminderChannel = client.channels.cache.get(reminder.channel_id);
-    //Only start timers if nextSpawn date is after current server time
-    if(timerCountdown >= 601000) {
-      console.log('Restarting Reminders');
-      const reminderTimeout = setTimeout(async () => {
-        const reminderTimerMessage = await sendReminderTimerEmbed(reminderChannel, role.role_id, timer);
-        setTimeout(async () => {
-          await editReminderTimerStatus(reminderTimerMessage, role.role_id, timer);//Edit timer message to display that world boss has started
-          await reminderTimerMessage.delete({ timeout: 1200000 }); //Delete timer message after 20 minutes as world boss has ended
-        }, 601000); //600000 - Fired 10 minutes after timer message is sent; during when world boss has started
-      }, timerCountdown - 601000); //600000 - 10 minutes before world boss spawns 
-
-      database.run(`UPDATE Reminder SET timer = ${reminderTimeout} WHERE uuid = "${reminder.uuid}"`, error => {
-        if(error){
-          console.log(error);
-        }
-      });
-    }
-  })
-}
 module.exports = {
   createRoleTable,
   insertNewRole,
   deleteRole,
-  updateRole,
-  createReminderRole,
-  startIndividualReminder
+  updateRole
 }


### PR DESCRIPTION
#### Context
Flesh out all the cases when reminders get initialised

- Enabling a newly created reminder with a newly created reminder role
- Enabling a newly created reminder but a reminder role already exists
- Enabling an existing reminder and a reminder role exists
- Enabling an existing reminder but a reminder role doesn't exist

Also fleshed out reminder reaction interactions as previously yagi just freezes and doesn't do anything when enabling a new reminder but a reminder reaction message already exists somewhere. Now we'll either send the reminder details if it exists so users can just be redirected to the original message and send a new reaction message if it doesn't.
![image](https://user-images.githubusercontent.com/42207245/126645978-5802afcf-e365-431d-8391-a8484ff9aec5.png)

#### Change
- Start timers for newly enabled reminders
- Allow reminder users to be unique to different servers
- Clear reminder timer when disablign a reminder
- Flesh out reminder reaction message if enabling new reminders
- Start reminder timers when re-enabling
- Refactor reminder reaction message initialisation

#### Release Notes
Flesh out reminders initialisation