### PR TITLE
Interactions when deleting elements

### DIFF
--- a/commands/reminder/remind.js
+++ b/commands/reminder/remind.js
@@ -17,7 +17,7 @@ module.exports = {
         case 'enable':
           return isAdmin ? enableReminder(message, yagi) : message.channel.send('Reminders can only be enabled by an admin');
         case 'disable':
-          return isAdmin ? disableReminder(message) : message.channel.send('Reminders can only be disabled by an admin');
+          return isAdmin ? disableReminder(message, yagi) : message.channel.send('Reminders can only be disabled by an admin');
         default:
           return message.channel.send('Only accepts `enable` or `disable` as arguments');
       }

--- a/database/channel-db.js
+++ b/database/channel-db.js
@@ -72,19 +72,6 @@ const deleteChannel = (channel) => {
     }
   })
 }
-const deleteAllChannels = (guild) => {
-  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.each(`SELECT * FROM Channel WHERE guild_id = ${guild.id}`, (error, row) => {
-    if(error){
-      console.log(error);
-    }
-    database.run(`DELETE FROM Channel WHERE uuid = ${row.uuid}`, err => {
-      if(err){
-        console.log(err);
-      }
-    })
-  })
-}
 /**
  * Updates data of existing channel with new details in database
  * Only setting name as that's the only parameter we're saving in our database that can be edited by a user
@@ -103,6 +90,5 @@ module.exports = {
   createChannelTable,
   insertNewChannel,
   deleteChannel,
-  deleteAllChannels,
   updateChannel
 }

--- a/database/guild-db.js
+++ b/database/guild-db.js
@@ -61,18 +61,6 @@ const insertNewGuild = (guild) => {
   })
 }
 /**
- * Deletes guild from Guild table
- * @param guild  - guild that yagi is removed in
- */
-const deleteGuild = (guild) => {
-  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.run(`DELETE FROM Guild WHERE uuid = ${guild.id}`, err => {
-    if(err){
-      console.log(err);
-    }
-  })
-}
-/**
  * Updates data of existing guild with new details in database
  * Only setting name as that's the only parameter we're saving in our database that can be edited by a user
  * @param guild - new updated details of guild
@@ -120,7 +108,6 @@ const updateGuildMemberCount = (member, type) => {
 module.exports = { 
   createGuildTable,
   insertNewGuild,
-  deleteGuild,
   updateGuild,
   updateGuildMemberCount
 }

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -276,6 +276,9 @@ const sendReminderInformation = (message, yagi) => {
             const reactionMessageInChannel = await reactionChannel.messages.fetch(reactionMessage.uuid); //Fetches message data from discord
             const embed = reminderDetails(enabledReminder.channel_id, role && role.role_id, reactionMessageInChannel.url);
             message.channel.send({ embed })
+          } else {
+            const embed = reminderDetails(enabledReminder.channel_id, role && role.role_id, null);
+            await message.channel.send({ embed });
           }
         })
       })

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -253,19 +253,17 @@ const sendReminderInformation = (message, yagi) => {
         if(error){
           console.log(error);
         }
-        if(role){
-          database.get(`SELECT * FROM ReminderReactionMessage WHERE uuid = "${enabledReminder.reaction_message_id}"`, async (error, reactionMessage) => {
-            if(error){
-              console.log(error)
-            }
-            if(reactionMessage){
-              const reactionChannel = await yagi.channels.fetch(reactionMessage.channel_id); //Fetches channel data from discord
-              const reactionMessageInChannel = await reactionChannel.messages.fetch(reactionMessage.uuid); //Fetches message data from discord
-              const embed = reminderDetails(enabledReminder.channel_id, role.role_id, reactionMessageInChannel.url);
-              message.channel.send({ embed })
-            }
-          })
-        }
+        database.get(`SELECT * FROM ReminderReactionMessage WHERE uuid = "${enabledReminder.reaction_message_id}"`, async (error, reactionMessage) => {
+          if(error){
+            console.log(error)
+          }
+          if(reactionMessage){
+            const reactionChannel = await yagi.channels.fetch(reactionMessage.channel_id); //Fetches channel data from discord
+            const reactionMessageInChannel = await reactionChannel.messages.fetch(reactionMessage.uuid); //Fetches message data from discord
+            const embed = reminderDetails(enabledReminder.channel_id, role && role.role_id, reactionMessageInChannel.url);
+            message.channel.send({ embed })
+          }
+        })
       })
     } else {
       const embed = reminderInstructions();

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -314,9 +314,9 @@ const startReminders = (database, client) => {
     if(timerCountdown >= 601000) {
       console.log('Restarting Reminders');
       const reminderTimeout = setTimeout(async () => {
-        const reminderTimerMessage = await sendReminderTimerEmbed(reminderChannel, role.role_id, timer);
+        const reminderTimerMessage = await sendReminderTimerEmbed(reminderChannel, role && role.role_id, timer);
         setTimeout(async () => {
-          await editReminderTimerStatus(reminderTimerMessage, role.role_id, timer);//Edit timer message to display that world boss has started
+          await editReminderTimerStatus(reminderTimerMessage, role && role.role_id, timer);//Edit timer message to display that world boss has started
           await reminderTimerMessage.delete({ timeout: 1800000 }); //Delete timer message after 20 minutes as world boss has ended (30 minutes after the parent timeout)
         }, 601000); //600000 - Fired 10 minutes after timer message is sent; during when world boss has started
       }, timerCountdown - 601000); //600000 - 10 minutes before world boss spawns 

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -59,13 +59,15 @@ const enableReminder = (message, client) => {
                 const embed = enableReminderEmbed(message, reminder)
                 message.channel.send({ embed });
               })
-              database.get(`SELECT * FROM Role WHERE uuid = "${reminder.role_uuid}"`, async (err, role) => {
+              database.get(`SELECT * FROM Role WHERE guild_id = "${message.guild.id}" AND used_for_reminder = ${true}`, async (err, role) => {
                 if(err){
                   console.log(err);
                 }
                 if(role){
-                  sendReminderReactionMessage(database, message, client, reminder, role);
-                  startIndividualReminder(database, reminder, role, client);
+                  database.run(`UPDATE Reminder SET role_uuid = "${role.uuid}" WHERE uuid = "${reminder.uuid}"`, error => {
+                    sendReminderReactionMessage(database, message, client, reminder, role);
+                    startIndividualReminder(database, reminder, role, client);
+                  });
                 } else {
                   createReminderRole(message, reminder, client);
                 }
@@ -73,6 +75,7 @@ const enableReminder = (message, client) => {
             })
           } else {
             //Creates a new reminder if it doesn't exist
+            console.log("insert new reminder");
             insertNewReminder(message, client);
           }
         })

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -75,7 +75,6 @@ const enableReminder = (message, client) => {
             })
           } else {
             //Creates a new reminder if it doesn't exist
-            console.log("insert new reminder");
             insertNewReminder(message, client);
           }
         })

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -133,8 +133,10 @@ const deleteReminderReactionMessage = (message) => {
           database.get(`SELECT * FROM Reminder WHERE reaction_message_id = ${message.id}`, (error, reminder) => {
             database.get(`SELECT * FROM Role WHERE uuid = "${reminder.role_uuid}"`, (error, role) => {
               database.each(`SELECT * FROM ReminderUser WHERE reminder_reaction_message_id = "${message.id}"`, async (error, user) => {
-                const memberToRemove = await message.guild.members.fetch(user.user_id);
-                memberToRemove.roles.remove(role.role_id);
+                if(role){
+                  const memberToRemove = await message.guild.members.fetch(user.user_id);
+                  memberToRemove.roles.remove(role.role_id);
+                }
                 database.run(`DELETE FROM ReminderUser WHERE uuid = "${user.uuid}"`);
               })
             })

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -91,6 +91,14 @@ const updateReminderReactionMessage = (reaction) => {
     }
   })
 }
+const checkIfReminderReactionMessage = (message) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.get(`SELECT * FROM ReminderReactionMessage WHERE uuid = "${message.id}"`, (error, reactionMessage) => {
+    if(reactionMessage && message.content === ''){
+      message.delete();
+    }
+  })
+}
 const deleteReminderReactionMessage = (message, client) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.serialize(() => {
@@ -160,6 +168,7 @@ module.exports = {
   insertNewReminderReactionMessage,
   cacheExistingReminderReactionMessages,
   updateReminderReactionMessage,
+  checkIfReminderReactionMessage,
   deleteReminderReactionMessage,
   sendReminderReactionMessage
 }

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -113,10 +113,10 @@ const updateReminderReactionMessage = (reaction) => {
     }
   })
 }
-const checkIfReminderReactionMessage = (message) => {
+const checkIfReminderReactionMessage = (message, oldMessage) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.get(`SELECT * FROM ReminderReactionMessage WHERE uuid = "${message.id}"`, (error, reactionMessage) => {
-    if(reactionMessage && message.content === '' && !(message.author.id === "582202266828668998" || message.author.id === "518196430104428579")){
+    if(reactionMessage && message.content === '' && oldMessage.embeds.length === 1 && message.embeds.length === 0 && (message.author.id === "582202266828668998" || message.author.id === "518196430104428579")){
       message.delete();
     }
   })

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -1,3 +1,4 @@
+const Discord = require('discord.js');
 const sqlite = require('sqlite3').verbose();
 const { reminderReactionMessage, reminderDetails } = require('../helpers');
 /**
@@ -110,6 +111,8 @@ const sendReminderReactionMessage = (database, message, client, reminder, role) 
        */
       const reactionChannel = await client.channels.fetch(reactionMessage.channel_id); //Fetches channel data from discord
       const reactionMessageInChannel = await reactionChannel.messages.fetch(reactionMessage.uuid); //Fetches message data from discord
+      const updatedReactionMessage = reminderReactionMessage(reminder.channel_id, role.role_id);
+      await reactionMessageInChannel.edit(new Discord.MessageEmbed(updatedReactionMessage));
       const embed = reminderDetails(reminder.channel_id, role.role_id, reactionMessageInChannel.url);
       database.run(`UPDATE Reminder SET reaction_message_id = "${reactionMessage.uuid}" WHERE uuid = "${reminder.uuid}"`, err => {
         message.channel.send({ embed });

--- a/database/reminder-reaction-message-db.js
+++ b/database/reminder-reaction-message-db.js
@@ -116,7 +116,7 @@ const updateReminderReactionMessage = (reaction) => {
 const checkIfReminderReactionMessage = (message) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.get(`SELECT * FROM ReminderReactionMessage WHERE uuid = "${message.id}"`, (error, reactionMessage) => {
-    if(reactionMessage && message.content === ''){
+    if(reactionMessage && message.content === '' && !(message.author.id === "582202266828668998" || message.author.id === "518196430104428579")){
       message.delete();
     }
   })

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -88,7 +88,7 @@ const setReminderRoleToUser = (reaction, user, type) => {
       console.log(error);
     }
     if(reminder){
-      database.get(`SELECT * FROM Role WHERE reminder_id = "${reminder.uuid}"`, async (error, role) => {
+      database.get(`SELECT * FROM Role WHERE uuid = "${reminder.role_uuid}"`, async (error, role) => {
         if(error){
           console.log(error);
         }

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -109,6 +109,5 @@ const setReminderRoleToUser = (reaction, user, type) => {
 }
 module.exports = {
   createReminderUserTable,
-  reactToMessage,
-  removeReminderUser
+  reactToMessage
 }

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -83,7 +83,7 @@ const removeReminderUser = (reaction, user) => {
  */
 const setReminderRoleToUser = (reaction, user, type) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.get(`SELECT * FROM Reminder WHERE guild_id = "${reaction.message.guild.id}" AND enabled = ${true}`, (error, reminder) => {
+  database.get(`SELECT * FROM Reminder WHERE guild_id = "${reaction.message.guild.id}"`, (error, reminder) => {
     if(error){
       console.log(error);
     }

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -109,5 +109,6 @@ const setReminderRoleToUser = (reaction, user, type) => {
 }
 module.exports = {
   createReminderUserTable,
-  reactToMessage
+  reactToMessage,
+  removeReminderUser
 }

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -83,7 +83,7 @@ const removeReminderUser = (reaction, user) => {
  */
 const setReminderRoleToUser = (reaction, user, type) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.get(`SELECT * FROM Reminder WHERE guild_id = "${reaction.message.guild.id}" AND enabled = ${true}`, (error, reminder) => {
+  database.get(`SELECT * FROM Reminder WHERE guild_id = "${reaction.message.guild.id}" AND NOT role_uuid IS NULL`, (error, reminder) => {
     if(error){
       console.log(error);
     }

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -83,6 +83,7 @@ const removeReminderUser = (reaction, user) => {
  */
 const setReminderRoleToUser = (reaction, user, type) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  //Adding a role_uuid is not null check so that we're getting the most updated reminder; this is so that we can set also roles when reminders are disabled
   database.get(`SELECT * FROM Reminder WHERE guild_id = "${reaction.message.guild.id}" AND NOT role_uuid IS NULL`, (error, reminder) => {
     if(error){
       console.log(error);
@@ -94,6 +95,7 @@ const setReminderRoleToUser = (reaction, user, type) => {
         }
         if(role){
           const memberToSet = await reaction.message.guild.members.fetch(user.id);
+          //Add catch handlers as there are edge cases when roles are deleted in discord but not in our database; adding this comment to populate this handler later on
           switch(type){
             case 'add': 
               try{

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -96,10 +96,18 @@ const setReminderRoleToUser = (reaction, user, type) => {
           const memberToSet = await reaction.message.guild.members.fetch(user.id);
           switch(type){
             case 'add': 
-              await memberToSet.roles.add(role.role_id);
+              try{
+                await memberToSet.roles.add(role.role_id);
+              } catch(e){
+                console.log(e);
+              }
             break;
             case 'remove':
-              await memberToSet.roles.remove(role.role_id);
+              try{
+                await memberToSet.roles.remove(role.role_id);
+              } catch(e){
+                console.log(e);
+              }
               break;
           }
         }

--- a/database/reminder-user-db.js
+++ b/database/reminder-user-db.js
@@ -83,7 +83,7 @@ const removeReminderUser = (reaction, user) => {
  */
 const setReminderRoleToUser = (reaction, user, type) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.get(`SELECT * FROM Reminder WHERE guild_id = "${reaction.message.guild.id}"`, (error, reminder) => {
+  database.get(`SELECT * FROM Reminder WHERE guild_id = "${reaction.message.guild.id}" AND enabled = ${true}`, (error, reminder) => {
     if(error){
       console.log(error);
     }

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -75,10 +75,17 @@ const insertNewRole = (role) => {
  */
 const deleteRole = (role) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.run(`DELETE FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, err => {
-    if(err){
-      console.log(err);
-    }
+  database.serialize(() => {
+    database.get(`SELECT * FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, (error, deletedRole) => {
+      if(deletedRole.used_for_reminder === 1){
+        database.run(`UPDATE Reminder SET role_uuid = ${null} WHERE uuid = "${deletedRole.reminder_id}"`);
+      }
+    })
+    database.run(`DELETE FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, err => {
+      if(err){
+        console.log(err);
+      }
+    })
   })
 }
 /**

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -119,9 +119,14 @@ const updateRole = (role) => {
     }
   })
 }
+const deleteAllRoles = (guild) => {
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+  database.run(`DELETE FROM Role WHERE guild_id = "${guild.id}"`);
+}
 module.exports = {
   createRoleTable,
   insertNewRole,
   deleteRole,
-  updateRole
+  updateRole,
+  deleteAllRoles
 }

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -71,18 +71,25 @@ const insertNewRole = (role) => {
 }
 /**
  * Deletes role from Role table
+ * Additional statements when role is being used for reminders
  * @param role - role that has been deleted
  */
 const deleteRole = (role, client) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.serialize(() => {
-    //Update reminders to not have a role if the deleted role is being used in a reminder
     database.get(`SELECT * FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, (error, deletedRole) => {
+      //Checks if deleted role is used in a reminder
       if(deletedRole.used_for_reminder === 1){
         database.serialize(() => {
+          //Delete all reminder users from our database in the current guild
           database.run(`DELETE FROM ReminderUser WHERE guild_id = "${deletedRole.guild_id}"`);
           database.get(`SELECT * FROM ReminderReactionMessage WHERE guild_id = "${deletedRole.guild_id}"`, async (error, reactionMessage) => {
             if(reactionMessage){
+              /**
+               * As the reminder role is deleted, we don't need to keep track of who still has reacted to the reaction message
+               * We remove all the goat reactions on the reaction message
+               * After they are all removed, the bot then reacts again. This is placeholder for now as there are no handlers to when users react to the message when there are no roles
+               */
               const channel = await client.channels.fetch(reactionMessage.channel_id);
               try {
                 const message = await channel.messages.fetch(reactionMessage.uuid);
@@ -97,6 +104,10 @@ const deleteRole = (role, client) => {
               }
             }
           })
+          /**
+           * To prevent complications, it's best to stop any active reminders when the reminder role is deleted
+           * We clear any timeouts that are active, send a special embed message and then update the reminder to be disabled
+           */
           database.get(`SELECT * FROM Reminder WHERE role_uuid = "${deletedRole.uuid}" AND enabled = ${true}`, async (error, reminder) => {
             if(reminder){
               if(reminder.timer){
@@ -108,6 +119,7 @@ const deleteRole = (role, client) => {
               database.run(`UPDATE Reminder SET timer = ${null}, enabled = ${false} WHERE uuid = "${reminder.uuid}"`);
             }
           })
+          //Update every reminder with the associated deleted role
           database.each(`SELECT * FROM Reminder WHERE role_uuid = "${deletedRole.uuid}"`, (error, reminder) => {
             if(reminder){
               database.run(`UPDATE Reminder SET role_uuid = ${null} WHERE uuid = "${reminder.uuid}"`);
@@ -116,6 +128,7 @@ const deleteRole = (role, client) => {
         })
       }
     })
+    //Delete role from our database
     database.run(`DELETE FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, err => {
       if(err){
         console.log(err);
@@ -136,14 +149,9 @@ const updateRole = (role) => {
     }
   })
 }
-const deleteAllRoles = (guild) => {
-  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
-  database.run(`DELETE FROM Role WHERE guild_id = "${guild.id}"`);
-}
 module.exports = {
   createRoleTable,
   insertNewRole,
   deleteRole,
-  updateRole,
-  deleteAllRoles
+  updateRole
 }

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -79,7 +79,11 @@ const deleteRole = (role) => {
     //Update reminders to not have a role if the deleted role is being used in a reminder
     database.get(`SELECT * FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, (error, deletedRole) => {
       if(deletedRole.used_for_reminder === 1){
-        database.run(`UPDATE Reminder SET role_uuid = ${null} WHERE uuid = "${deletedRole.reminder_id}"`);
+        database.each(`SELECT * FROM Reminder WHERE role_uuid = "${deletedRole.uuid}"`, (error, reminder) => {
+          if(reminder){
+            database.run(`UPDATE Reminder SET role_uuid = ${null} WHERE uuid = "${reminder.uuid}"`);
+          }
+        })
       }
     })
     database.run(`DELETE FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, err => {

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -94,6 +94,7 @@ const deleteRole = (role, client) => {
                 await reaction.remove();
               }
             })
+            await message.react('%F0%9F%90%90');
           })
         })
       }

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -70,12 +70,13 @@ const insertNewRole = (role) => {
   })
 }
 /**
- * Deletes crole from Role table
+ * Deletes role from Role table
  * @param role - role that has been deleted
  */
 const deleteRole = (role) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.serialize(() => {
+    //Update reminders to not have a role if the deleted role is being used in a reminder
     database.get(`SELECT * FROM Role WHERE role_id = ${role.id} AND guild_id = ${role.guild.id}`, (error, deletedRole) => {
       if(deletedRole.used_for_reminder === 1){
         database.run(`UPDATE Reminder SET role_uuid = ${null} WHERE uuid = "${deletedRole.reminder_id}"`);

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -73,7 +73,7 @@ const insertNewRole = (role) => {
  * Deletes role from Role table
  * @param role - role that has been deleted
  */
-const deleteRole = (role) => {
+const deleteRole = (role, client) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
   database.serialize(() => {
     //Update reminders to not have a role if the deleted role is being used in a reminder
@@ -86,6 +86,15 @@ const deleteRole = (role) => {
             }
           })
           database.run(`DELETE FROM ReminderUser WHERE guild_id = "${deletedRole.guild_id}"`);
+          database.get(`SELECT * FROM ReminderReactionMessage WHERE guild_id = "${deletedRole.guild_id}"`, async (error, reactionMessage) => {
+            const channel = await client.channels.fetch(reactionMessage.channel_id);
+            const message = await channel.messages.fetch(reactionMessage.uuid);
+            message.reactions.cache.forEach(async reaction => {
+              if(reaction.emoji.name === '🐐'){
+                await reaction.remove();
+              }
+            })
+          })
         })
       }
     })

--- a/database/role-db.js
+++ b/database/role-db.js
@@ -87,14 +87,20 @@ const deleteRole = (role, client) => {
           })
           database.run(`DELETE FROM ReminderUser WHERE guild_id = "${deletedRole.guild_id}"`);
           database.get(`SELECT * FROM ReminderReactionMessage WHERE guild_id = "${deletedRole.guild_id}"`, async (error, reactionMessage) => {
-            const channel = await client.channels.fetch(reactionMessage.channel_id);
-            const message = await channel.messages.fetch(reactionMessage.uuid);
-            message.reactions.cache.forEach(async reaction => {
-              if(reaction.emoji.name === '🐐'){
-                await reaction.remove();
+            if(reactionMessage){
+              const channel = await client.channels.fetch(reactionMessage.channel_id);
+              try {
+                const message = await channel.messages.fetch(reactionMessage.uuid);
+                message.reactions.cache.forEach(async reaction => {
+                  if(reaction.emoji.name === '🐐'){
+                    await reaction.remove();
+                  }
+                })
+                await message.react('%F0%9F%90%90');
+              } catch(e){
+                throw e;
               }
-            })
-            await message.react('%F0%9F%90%90');
+            }
           })
         })
       }

--- a/helpers.js
+++ b/helpers.js
@@ -280,6 +280,9 @@ const disableReminderEmbed = (message, reminder) => {
   }
   return embed;
 }
+/**
+ * Embed design used when disabling reminders after the reminder role is deleted
+ */
 const disableReminderEmbedWhenRoleIsDeleted = () => {
   const embed = {
     title: "Reminder disabled!",
@@ -288,6 +291,9 @@ const disableReminderEmbedWhenRoleIsDeleted = () => {
   }
   return embed;
 }
+/**
+ * Embed design used when disabling reminders after the reminder reaction message is deleted
+ */
 const disableReminderEmbedWhenReactionIsDeleted = () => {
   const embed = {
     title: "Reminder disabled!",
@@ -380,12 +386,12 @@ const reminderDetails = (channel, role, message) => {
       },
       {
         name: "Reminder Role",
-        value: role ? `<@&${role}>` : '@deleted-role',
+        value: role ? `<@&${role}>` : '@deleted-role', //Add empty state if role does not exist
         inline: true
       },
       {
         name: "Reaction Message",
-        value: message ? `[Click me! (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧](${message})` : '-'
+        value: message ? `[Click me! (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧](${message})` : '-' //Add empty state if message does not exist
 
       }
     ]
@@ -411,12 +417,12 @@ const reminderReactionMessage = (channel, role) => {
     fields: [
       {
         name: "Active Channel",
-        value: channel ? `<#${channel}>` : '-',
+        value: channel ? `<#${channel}>` : '-', //Add empty state if channel does not exist
         inline: true
       },
       {
         name: "Reminder Role",
-        value: role ? `<@&${role}>` : '@deleted-role',
+        value: role ? `<@&${role}>` : '@deleted-role', //Add empty state if role does not exist
         inline: true
       }
     ]
@@ -638,7 +644,7 @@ const sendReminderTimerEmbed = (channel, role, worldBoss) => {
       }
     ]
   }
-  const roleId = role ? `<@&${role}>` : '@deleted-role';
+  const roleId = role ? `<@&${role}>` : '@deleted-role'; //Add empty state if role does not exist
   return channel.send(`${roleId} Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
 }
 //----------
@@ -674,7 +680,7 @@ const editReminderTimerStatus = (message, role, worldBoss) => {
       }
     ]
   }
-  const roleId = role ? `<@&${role}>` : '@deleted-role';
+  const roleId = role ? `<@&${role}>` : '@deleted-role'; //Add empty state if role does not exist
   return message.edit(`${roleId} Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
 }
 //----------

--- a/helpers.js
+++ b/helpers.js
@@ -622,7 +622,8 @@ const sendReminderTimerEmbed = (channel, role, worldBoss) => {
       }
     ]
   }
-  return channel.send(`<@&${role}> Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
+  const roleId = role ? `<@&${role}>` : '@deleted-role';
+  return channel.send(`${roleId} Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
 }
 //----------
 /**
@@ -657,7 +658,8 @@ const editReminderTimerStatus = (message, role, worldBoss) => {
       }
     ]
   }
-  return message.edit(`<@&${role}> Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
+  const roleId = role ? `<@&${role}>` : '@deleted-role';
+  return message.edit(`${roleId} Wake up Envoys, we have goats to hunt (ง •̀_•́)ง`, { embed });
 }
 //----------
 /**

--- a/helpers.js
+++ b/helpers.js
@@ -395,12 +395,12 @@ const reminderReactionMessage = (channel, role) => {
     fields: [
       {
         name: "Active Channel",
-        value: `<#${channel}>`,
+        value: channel ? `<#${channel}>` : '-',
         inline: true
       },
       {
         name: "Reminder Role",
-        value: `<@&${role}>`,
+        value: role ? `<@&${role}>` : '@deleted-role',
         inline: true
       }
     ]

--- a/helpers.js
+++ b/helpers.js
@@ -283,7 +283,7 @@ const disableReminderEmbed = (message, reminder) => {
 const disableReminderEmbedWhenRoleIsDeleted = () => {
   const embed = {
     title: "Reminder disabled!",
-    description: "The reminder role has been deleted, reminder has been temporarily disabled. To recreate the role, simply re-enable a reminder by typing `$yagi-remind enable`.",
+    description: "The reminder role has been deleted, reminder is temporarily disabled. To recreate the role, simply re-enable a reminder by typing `$yagi-remind enable`.",
     color: 16711680
   }
   return embed;
@@ -291,7 +291,7 @@ const disableReminderEmbedWhenRoleIsDeleted = () => {
 const disableReminderEmbedWhenReactionIsDeleted = () => {
   const embed = {
     title: "Reminder disabled!",
-    description: "The reaction message has been deleted, reminder has been temporarily disabled. To recreate the reaction message, simply re-enable a reminder by typing `$yagi-remind enable`.",
+    description: "The reaction message has been deleted, reminder is temporarily disabled. To recreate the reaction message, simply re-enable a reminder by typing `$yagi-remind enable`.",
     color: 16711680
   }
   return embed;

--- a/helpers.js
+++ b/helpers.js
@@ -364,7 +364,7 @@ const reminderDetails = (channel, role, message) => {
       },
       {
         name: "Reminder Role",
-        value: `<@&${role}>`,
+        value: role ? `<@&${role}>` : '@deleted-role',
         inline: true
       },
       {

--- a/helpers.js
+++ b/helpers.js
@@ -369,7 +369,7 @@ const reminderDetails = (channel, role, message) => {
       },
       {
         name: "Reaction Message",
-        value: `[Click me! (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧](${message})`,
+        value: message ? `[Click me! (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧](${message})` : '-'
 
       }
     ]

--- a/helpers.js
+++ b/helpers.js
@@ -280,6 +280,22 @@ const disableReminderEmbed = (message, reminder) => {
   }
   return embed;
 }
+const disableReminderEmbedWhenRoleIsDeleted = () => {
+  const embed = {
+    title: "Reminder disabled!",
+    description: "The reminder role has been deleted, reminder has been temporarily disabled. To recreate the role, simply re-enable a reminder by typing `$yagi-remind enable`.",
+    color: 16711680
+  }
+  return embed;
+}
+const disableReminderEmbedWhenReactionIsDeleted = () => {
+  const embed = {
+    title: "Reminder disabled!",
+    description: "The reaction message has been deleted, reminder has been temporarily disabled. To recreate the reaction message, simply re-enable a reminder by typing `$yagi-remind enable`.",
+    color: 16711680
+  }
+  return embed;
+}
 /**
  * Embed design used when enabling reminders
  * First checks if message was sent in the reminder-enabled channel and if reminder even exists
@@ -713,6 +729,8 @@ module.exports = {
   sendErrorLog,
   generateUUID,
   disableReminderEmbed,
+  disableReminderEmbedWhenRoleIsDeleted,
+  disableReminderEmbedWhenReactionIsDeleted,
   enableReminderEmbed,
   reminderInstructions,
   reminderDetails,

--- a/yagi.js
+++ b/yagi.js
@@ -9,7 +9,7 @@ const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildM
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
 const { createReminderTable } = require('./database/reminder-db.js');
-const { cacheExistingReminderReactionMessages, updateReminderReactionMessage, deleteReminderReactionMessage } = require('./database/reminder-reaction-message-db.js');
+const { cacheExistingReminderReactionMessages, updateReminderReactionMessage, deleteReminderReactionMessage, checkIfReminderReactionMessage } = require('./database/reminder-reaction-message-db.js');
 const { createReminderUserTable, reactToMessage, removeReminderUser } = require('./database/reminder-user-db.js');
 const { createTimerTable, getCurrentTimerData } = require('./database/timer-db.js');
 const { sendMixpanelEvent } = require('./analytics');
@@ -236,9 +236,8 @@ yagi.on('messageReactionRemove', (reaction, user) => {
   removeReminderUser(reaction, user);
 })
 //------
-yagi.on('messageUpdate', (oldMessage, newMessage) => {
-  console.log(newMessage.content);
-  console.log(newMessage.content === '');
+yagi.on('messageUpdate', (_, newMessage) => {
+  checkIfReminderReactionMessage(newMessage);
 })
 yagi.on('messageDelete', (message) => {
   deleteReminderReactionMessage(message);

--- a/yagi.js
+++ b/yagi.js
@@ -238,7 +238,7 @@ yagi.on('messageUpdate', (_, newMessage) => {
   checkIfReminderReactionMessage(newMessage);
 })
 yagi.on('messageDelete', (message) => {
-  deleteReminderReactionMessage(message);
+  deleteReminderReactionMessage(message, yagi);
 })
 //------
 /**

--- a/yagi.js
+++ b/yagi.js
@@ -207,7 +207,7 @@ yagi.on('roleCreate', (role) => {
 })
 yagi.on('roleDelete', (role) => {
   try {
-    deleteRole(role);
+    deleteRole(role, yagi);
   } catch(e){
     sendErrorLog(yagi, e)
   }

--- a/yagi.js
+++ b/yagi.js
@@ -234,8 +234,8 @@ yagi.on('messageReactionRemove', (reaction, user) => {
   removeReminderUser(reaction, user);
 })
 //------
-yagi.on('messageUpdate', (_, newMessage) => {
-  checkIfReminderReactionMessage(newMessage);
+yagi.on('messageUpdate', (oldMessage, newMessage) => {
+  checkIfReminderReactionMessage(newMessage, oldMessage);
 })
 yagi.on('messageDelete', (message) => {
   deleteReminderReactionMessage(message, yagi);

--- a/yagi.js
+++ b/yagi.js
@@ -234,6 +234,12 @@ yagi.on('messageReactionRemove', (reaction, user) => {
   removeReminderUser(reaction, user);
 })
 //------
+/**
+ * Event handlers for when message is updated and deleted
+ * messageUpdate - called when a user edits a cached message
+ * messageDelete - called when a user deletes a cached message
+ * More information about each function in their relevant database files
+ */
 yagi.on('messageUpdate', (oldMessage, newMessage) => {
   checkIfReminderReactionMessage(newMessage, oldMessage);
 })
@@ -306,6 +312,18 @@ const createYagiDatabase = () => {
   let db = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE | sqlite.OPEN_CREATE);
   return db;
 }
+/**
+ * Function to delete all the relevant data in our database when yagi is removed from a server
+ * Removes:
+ * Guild
+ * Channel
+ * Role
+ * ReminderUser
+ * ReminderReactionMessage
+ * Reminder
+ * We clear any active reminders associated to the guild and then send the guild update notification to goat-servers in Yagi's Den
+ * @param guild - guild in which yagi was kicked in
+ */
 const removeServerDataFromYagi = (guild) => {
   let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE | sqlite.OPEN_CREATE);
   database.serialize(() => {

--- a/yagi.js
+++ b/yagi.js
@@ -9,7 +9,7 @@ const { createGuildTable, insertNewGuild, deleteGuild, updateGuild, updateGuildM
 const { createChannelTable, insertNewChannel, deleteChannel, deleteAllChannels, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
 const { createReminderTable } = require('./database/reminder-db.js');
-const { cacheExistingReminderReactionMessages, updateReminderReactionMessage} = require('./database/reminder-reaction-message-db.js');
+const { cacheExistingReminderReactionMessages, updateReminderReactionMessage, deleteReminderReactionMessage } = require('./database/reminder-reaction-message-db.js');
 const { createReminderUserTable, reactToMessage, removeReminderUser } = require('./database/reminder-user-db.js');
 const { createTimerTable, getCurrentTimerData } = require('./database/timer-db.js');
 const { sendMixpanelEvent } = require('./analytics');
@@ -234,6 +234,14 @@ yagi.on('messageReactionAdd', async (reaction, user) => {
 yagi.on('messageReactionRemove', (reaction, user) => {
   updateReminderReactionMessage(reaction);
   removeReminderUser(reaction, user);
+})
+//------
+yagi.on('messageUpdate', (oldMessage, newMessage) => {
+  console.log(newMessage.content);
+  console.log(newMessage.content === '');
+})
+yagi.on('messageDelete', (message) => {
+  deleteReminderReactionMessage(message);
 })
 //------
 /**


### PR DESCRIPTION
#### Context
TECH DEBT GALORE BUT I DONT CARE JUST END MY SUFFERING. Let future me handle this and hate present me later. Pretty much just fleshed out interactions of all the elements related to reminders. I manually tested them one by one so they probably are stable 🤷  I'll add automated tests after v2.5 along with interactions when yagi restarts after a long period and there are changes to the reminder elements while he was offline. I'm just betting on the fact that yagi would have near perfect uptime so these edge cases shouldn't matter for now. 

What a wild ass ride. Can't believe it's done, yagi really has come a long way. Personally I'm just happy I can finally release this tmrw because it got a bit stale and unmotivating towards the end. At least once this is out, I can finally put in all my efforts towards v3 and all the exciting stuff of automation.

I'm too exhausted to put screenshots so just read the commit changes 

#### Change
- Add @deleted-role when role does not exist when reminding
- Add @delete-role in reminder details when role does not exist
- Update every reminder in server when reminder role gets deleted
- Delete all reminder users in guild when reminder role is deleted
- Remove goat reaction for all users in reaction message when role is deleted
- Edit reaction message when enabling/disabling a new reminder
- Allow setting of role even if there are no reminders of enabled
- Use existing role when enabling an existing disabled reminder instead of creating new one
- Delete reminder users when deleting reaction message
- Remove roles from users when deleting reaction message
- Delete reaction message if user removes embed from message
- Delete reminder reaction data on restart if message has been deleted
- Stop active reminder when role has been deleted
- Stop active reminder when reaction message has been deleted
- Delete all relevant data when yagi is kicked from server

#### Release Notes
Interactions when deleting elements