### PR TITLE
Add interactions for weekly maintenance

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -6,7 +6,7 @@
  * I do regret not implementing this right in the begininng but better late than never? It's been one hell of a learning experience anyway and I doubt I'll forget to add these in new projects
  * For reference: https://developer.mixpanel.com/docs/nodejs
  */
- const sendMixpanelEvent = (user, channel, guild, command, client) => {
+ const sendMixpanelEvent = (user, channel, guild, command, client, arguments) => {
   const eventToSend = `Use ${command} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
   /**
    * Creates and updates a user profile
@@ -33,7 +33,8 @@
       channel_id: channel.id,
       guild: guild.name,
       guild_id: guild.id,
-      command: command
+      command: command,
+      arguments: arguments ? arguments : 'none'
     })
     /**
      * Sets a user profile properties only once

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,6 +1,6 @@
 const Discord = require('discord.js');
 const sqlite = require('sqlite3').verbose();
-const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails, sendReminderTimerEmbed, getServerTime, editReminderTimerStatus, reminderReactionMessage, sendHealthLog } = require('../helpers');
+const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails, sendReminderTimerEmbed, getServerTime, editReminderTimerStatus, reminderReactionMessage, sendHealthLog, isInWeeklyMaintenance } = require('../helpers');
 const { sendReminderReactionMessage } = require('./reminder-reaction-message-db.js');
 const { differenceInMilliseconds } = require('date-fns');
 
@@ -317,10 +317,13 @@ const startReminders = (database, client) => {
   database.each(`SELECT * FROM Reminder WHERE enabled = ${true}`, (error, reminder) => {
     if(reminder){
       database.get(`SELECT * FROM Role WHERE uuid = "${reminder.role_uuid}"`, (error, role) => {
-        if(reminder.timer){
-          clearTimeout(reminder.timer);
-        }
-        startIndividualReminder(database, reminder, role, client);
+        database.serialize(() => {
+          if(reminder.timer){
+            clearTimeout(reminder.timer);
+            database.run(`UPDATE Reminder SET timer = ${null} WHERE uuid = "${reminder.uuid}"`);
+          }
+          startIndividualReminder(database, reminder, role, client);
+        })
       })
     }
   })
@@ -343,7 +346,7 @@ const startReminders = (database, client) => {
     const timerCountdown = differenceInMilliseconds(timer.next_spawn, getServerTime());
     const reminderChannel = client.channels.cache.get(reminder.channel_id);
     //Only start timers if nextSpawn date is after current server time
-    if(timerCountdown >= 601000) {
+    if(timerCountdown >= 601000 && !isInWeeklyMaintenance(timer.accurate === 1)) {
       console.log('Restarting Reminders');
       const reminderTimeout = setTimeout(async () => {
         const reminderTimerMessage = await sendReminderTimerEmbed(reminderChannel, role && role.role_id, timer);

--- a/database/reminder-db.js
+++ b/database/reminder-db.js
@@ -1,6 +1,6 @@
 const Discord = require('discord.js');
 const sqlite = require('sqlite3').verbose();
-const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails, sendReminderTimerEmbed, getServerTime, editReminderTimerStatus, reminderReactionMessage } = require('../helpers');
+const { generateUUID, disableReminderEmbed, enableReminderEmbed, reminderInstructions, reminderDetails, sendReminderTimerEmbed, getServerTime, editReminderTimerStatus, reminderReactionMessage, sendHealthLog } = require('../helpers');
 const { sendReminderReactionMessage } = require('./reminder-reaction-message-db.js');
 const { differenceInMilliseconds } = require('date-fns');
 
@@ -68,6 +68,9 @@ const enableReminder = (message, client) => {
                   database.run(`UPDATE Reminder SET role_uuid = "${role.uuid}" WHERE uuid = "${reminder.uuid}"`, error => {
                     sendReminderReactionMessage(database, message, client, reminder, role);
                     startIndividualReminder(database, reminder, role, client);
+
+                    const healthChannel = client.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
+                    sendHealthLog(healthChannel, null, null, 'reminder', reminder, client);
                   });
                 } else {
                   createReminderRole(message, reminder, client);
@@ -143,6 +146,9 @@ const enableReminder = (message, client) => {
             }
             startIndividualReminder(database, reminder, role, client);
             sendReminderReactionMessage(database, message, client, reminder, role);
+
+            const healthChannel = client.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
+            sendHealthLog(healthChannel, null, null, 'reminder', reminder, client);
           })
         })
       } else {
@@ -243,6 +249,9 @@ const disableReminder = (message, client) => {
             }
             sendReminderReactionMessage(database, message, client, reminder, role);
             startIndividualReminder(database, reminder, role, client);
+
+            const healthChannel = client.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
+            sendHealthLog(healthChannel, null, null, 'reminder', reminder, client);
           })
         }
       })

--- a/database/timer-db.js
+++ b/database/timer-db.js
@@ -89,7 +89,7 @@ const getCurrentTimerData = (client) => {
         const validatedWorldBossData = validateWorldBossData(worldBossData, serverTime);
         updateTimerData(database, validatedWorldBossData, timer);
         
-        sendHealthLog(healthChannel, worldBossData, validatedWorldBossData);
+        sendHealthLog(healthChannel, worldBossData, validatedWorldBossData, 'timer');
       }
     })
     startReminders(database, client);

--- a/helpers.js
+++ b/helpers.js
@@ -17,8 +17,7 @@ const {
   isWithinRange,
   startOfDay,
   endOfDay,
-  isWednesday,
-  isMonday
+  isWednesday
 } = require('date-fns');
 const { v4: uuidv4 } = require('uuid');
 const { currentOffset } = require('./config/offset.json');
@@ -778,12 +777,21 @@ const sendHealthLog = (channel, rawData, trueData, type, reminder, client) => {
   }
 }
 //----------
+/**
+ * Function to check if the game's servers down for weekly maintenance
+ * Currently this is just an assumption as there's nothing set up to get the server status
+ * Using a fixed date based on when maintenance usually happens i.e. on Wednesdays early morning
+ * Usually it starts at 3AM which is accurate enough but the end time varies
+ * To try to be as accurate as possible, I put the end time to 12pm and check if the timer data is accurate
+ * As leads would most certainly be updating the sheet after maintenance, this should be accurate enough
+ * @param timerIsAccurate - if validated world boss data is accurate
+ */
 const isInWeeklyMaintenance = (timerIsAccurate) => {
   const serverTime = getServerTime();
-  const isOnMonday = isMonday(serverTime);
+  const isOnWednesday = isWednesday(serverTime);
   const startOfMaint = `${format(serverTime, 'MMMM D YYYY 3:00:00')} AM`;
-  const endOfMaint = `${format(serverTime, 'MMMM D YYYY 12:00:00')} PM`;
-  return isOnMonday && isWithinRange(serverTime, startOfMaint, endOfMaint);
+  const endOfMaint = `${format(serverTime, 'MMMM D YYYY 12:00:00')} PM`; 
+  return isOnWednesday && isWithinRange(serverTime, startOfMaint, endOfMaint) && !timerIsAccurate;
 }
 //----------
 module.exports = {

--- a/helpers.js
+++ b/helpers.js
@@ -16,7 +16,9 @@ const {
   format,
   isWithinRange,
   startOfDay,
-  endOfDay
+  endOfDay,
+  isWednesday,
+  isMonday
 } = require('date-fns');
 const { v4: uuidv4 } = require('uuid');
 const { currentOffset } = require('./config/offset.json');
@@ -776,6 +778,14 @@ const sendHealthLog = (channel, rawData, trueData, type, reminder, client) => {
   }
 }
 //----------
+const isInWeeklyMaintenance = (timerIsAccurate) => {
+  const serverTime = getServerTime();
+  const isOnMonday = isMonday(serverTime);
+  const startOfMaint = `${format(serverTime, 'MMMM D YYYY 3:00:00')} AM`;
+  const endOfMaint = `${format(serverTime, 'MMMM D YYYY 12:00:00')} PM`;
+  return isOnMonday && isWithinRange(serverTime, startOfMaint, endOfMaint);
+}
+//----------
 module.exports = {
   getServerTime,
   formatCountdown,
@@ -799,5 +809,6 @@ module.exports = {
   codeBlock,
   sendReminderTimerEmbed,
   editReminderTimerStatus,
-  sendHealthLog
+  sendHealthLog,
+  isInWeeklyMaintenance
 }

--- a/yagi.js
+++ b/yagi.js
@@ -101,7 +101,7 @@ yagi.once('ready', async () => {
       getCurrentTimerData(yagi);
     }, 1800000, yagi) //1800000 - 30 minutes
     const healthChannel = yagi.channels.cache.get('866297328159686676'); //goat-health channel in Yagi's Den
-    sendHealthLog(healthChannel, worldBossData, validatedWorldBossData);
+    sendHealthLog(healthChannel, worldBossData, validatedWorldBossData, 'timer');
   } catch(e){
     sendErrorLog(yagi, e);
   }

--- a/yagi.js
+++ b/yagi.js
@@ -4,7 +4,7 @@ const commands = require('./commands');
 const yagi = new Discord.Client();
 const sqlite = require('sqlite3').verbose();
 const Mixpanel = require('mixpanel');
-const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment, getWorldBossData, getServerTime, validateWorldBossData, sendHealthLog } = require('./helpers');
+const { sendGuildUpdateNotification, sendErrorLog, checkIfInDevelopment, getWorldBossData, getServerTime, validateWorldBossData, sendHealthLog, isInWeeklyMaintenance } = require('./helpers');
 const { createGuildTable, insertNewGuild, updateGuild, updateGuildMemberCount } = require('./database/guild-db.js');
 const { createChannelTable, insertNewChannel, deleteChannel, updateChannel } = require('./database/channel-db.js');
 const { createRoleTable, insertNewRole, deleteRole, updateRole } = require('./database/role-db.js');
@@ -97,6 +97,7 @@ yagi.once('ready', async () => {
      * However, we don't want to spam requests on the sheet so we'll only ping if our current timer data on our end is either innacurate or the next spawn date has already passed
      * For more documentation, see the timer-db file
      */
+    isInWeeklyMaintenance();
     setInterval(() => {
       getCurrentTimerData(yagi);
     }, 1800000, yagi) //1800000 - 30 minutes

--- a/yagi.js
+++ b/yagi.js
@@ -291,7 +291,7 @@ yagi.on('message', async (message) => {
           await message.channel.send("That command doesn't accept arguments （・□・；）");
         } else {
           await commands[command].execute(message, arguments, yagi, commands, yagiPrefix);
-          sendMixpanelEvent(message.author, message.channel, message.channel.guild, command, mixpanel); //Send tracking event to mixpanel
+          sendMixpanelEvent(message.author, message.channel, message.channel.guild, command, mixpanel, arguments); //Send tracking event to mixpanel
         }
       } else {
         await message.channel.send("I'm not sure what you meant by that! （・□・；）");


### PR DESCRIPTION
#### Context
Adding a check for when servers are down for weekly maintenance. More so on temporarily stopping active reminders but added a new design embed when someone uses the `goats` command. Also added arguments to mixpanel events for better data breakdown along with sending a health log when a reminder gets enabled. Last implementation change pog

![image](https://user-images.githubusercontent.com/42207245/127035825-ae74dedd-bc1b-4ffb-85a3-19161192d1be.png)
![image](https://user-images.githubusercontent.com/42207245/127036636-617dcd5f-637e-4b9c-ad1f-04336f01d8e7.png)

#### Change
- Add arguments to mixpanel events
- Add active reminders to health log
- Send health log when reminder is enabled
- Add weekly maintenance check
- Send maintenance info when using `goats` while on maintenance
- Stop reminder timers if it's maintenance

#### Release Notes
Add interactions for weekly maintenance