### PR TITLE
Update commands content

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -29,6 +29,7 @@ module.exports = {
   loot: require('./commands/misc/loot'),
   website: require('./commands/misc/website'),
   contacts: require('./commands/misc/contacts'),
+  feedback: require('./commands/misc/feedback'),
   prefix: require('./commands/misc/prefix')
   // ----------
 };

--- a/commands/hub/help.js
+++ b/commands/hub/help.js
@@ -16,7 +16,7 @@ module.exports = {
         fields: [
           {
             name: 'Timer',
-            value: '`goats`'
+            value: '`goats`, `remind`'
           },
           {
             name: 'Information',
@@ -25,7 +25,7 @@ module.exports = {
           {
             name: 'Miscellaneous',
             value:
-              '`loot`, `contacts`, `website`\n\nFor more detailed information about a command, use `' +
+              '`loot`, `contacts`, `website`, `feedback`\n\nFor more detailed information about a command, use `' +
               yagiPrefix +
               'help <Command>`'
           }

--- a/commands/hub/info.js
+++ b/commands/hub/info.js
@@ -33,6 +33,16 @@ const sendInfoEmbed = function designOfYagiInformationEmbed(message, yagi, yagiP
         inline: true
       },
       {
+        name: 'Support Server',
+        value: '[Come join!](https://discord.gg/7nAYYDm)',
+        inline: true
+      },
+      {
+        name: 'Feedback Form',
+        value: '[Click me! (◕ᴗ◕✿)](https://cyhmwysg8uq.typeform.com/to/szg4bUPU)',
+        inline: true
+      },
+      {
         name: 'Dev Update | 10 March 2021',
         value: `Hey guys! Think it's been just over a month since my last update, haven't really been adding any major stuff to yagi. Mostly maintenance and dev commands. My main focus has been elsewhere extracting data and building an API for the game. But before I put in all my efforts in all that interesting stuff, I'll be releasing one more major feature to yagi: [Reminders](https://miro.com/app/board/o9J_lUIhhl0=/)! Will probably get this out in the next couple of weeks and after that, I don't expect to update yagi much until I get the API up and running. Till then o/`
       }

--- a/commands/misc/contacts.js
+++ b/commands/misc/contacts.js
@@ -23,10 +23,7 @@ module.exports = {
         },
         {
           name: 'Yagi',
-          value:
-            "• Use yagi's `message` command\n• This sends a message through the bot to me and I'll try to reply whenever I can!\n• For help, type `" +
-            currentPrefix +
-            'help message`'
+          value: '• [Discord Support Server](https://discord.gg/7nAYYDm)\n• [Codebase](https://github.com/vexuas/yagi)',
         },
         {
           name: 'Others',

--- a/commands/misc/feedback.js
+++ b/commands/misc/feedback.js
@@ -1,0 +1,11 @@
+module.exports = {
+  name: 'feedback',
+  description: `Displays a feedback form and invite link to yagi's support server`,
+  execute(message) {
+    const embed = {
+      description: `Thanks for using yagi ${message.author}!\n\nIf you have any feedback, feel free to add them [here! (◕ᴗ◕✿)](https://cyhmwysg8uq.typeform.com/to/szg4bUPU)\n\nOr join the [support server](https://discord.gg/7nAYYDm) if you have any questions and want to keep up-to-date with yagi's development!`,
+      color: 32896
+    }
+    message.channel.send({ embed });
+  }
+};

--- a/helpers.js
+++ b/helpers.js
@@ -184,20 +184,22 @@ const descriptionEmbed = function generatesDescriptionEmbedForCommands(
 ) {
   const commandName = `${grvAcnt}${currentPrefix}${command}${grvAcnt}`;
   const argumentUsage = `${grvAcnt}${currentPrefix}${command} ${exampleArgument}${grvAcnt}`;
+  let embed;
 
-  const embed = {
-    color: 32896,
-    fields: [
-      {
-        name: commandName,
-        value: description,
-      },
-      {
-        name: 'Usage',
-        value: hasArguments ? `${commandName} | ${argumentUsage}` : commandName,
-      },
-    ],
-  };
+  if(command !== 'remind'){
+    embed = {
+      description: description,
+      color: 32896,
+      fields: [
+        {
+          name: 'Usage',
+          value: hasArguments ? `${commandName} | ${argumentUsage}` : commandName,
+        },
+      ],
+    };
+  } else {
+    embed = reminderInstructions();
+  }
   return embed;
 };
 //----------
@@ -351,7 +353,7 @@ const reminderInstructions = () => {
       },
       {
         name: "How to use",
-        value: "1. When a channel is activated, Yagi creates a new role in the server `@Goat Hunters`\n2. To get reminders, simply react on the special message with :goat: and you will automatically get the role. *Note that by removing the reaction you will lose the role*\n3. When world boss is spawning soon, Yagi will ping the role\n\n*To get the special message again, type `$yagi-remind`. You can also edit the role to customise its name/color*"
+        value: "1. When a channel is activated, Yagi creates a new role in the server `@Goat Hunters`\n2. To get reminders, simply react on the special message with :goat: and you will automatically get the role. *Note that by removing the reaction you will lose the role*\n3. When world boss is spawning soon, Yagi will ping the role\n\n*To see the reminder details, type `$yagi-remind`. You can also edit the role to customise its name/color*"
       },
       {
         name: "How to disable",
@@ -665,7 +667,7 @@ const editReminderTimerStatus = (message, role, worldBoss) => {
   const spawnDescription = `Spawn: ${codeBlock(spawnText)}`;
  
   //Don't forget to add typeform and yagi's discord server invite
-  const spawnFooter = `*This feature is currently in beta. If you have any feedback, feel free to leave it [here](https://www.google.com/)! Or join the [support server](https://discord.gg/7nAYYDm) if you have any questions and want to keep up-to-date with yagi's development!*`
+  const spawnFooter = `*This feature is currently in beta. If you have any feedback, feel free to leave it [here](https://cyhmwysg8uq.typeform.com/to/szg4bUPU)! Or join the [support server](https://discord.gg/7nAYYDm) if you have any questions and want to keep up-to-date with yagi's development!*`
 
   const embed = {
     title: 'Olympus | World Boss',

--- a/helpers.js
+++ b/helpers.js
@@ -290,7 +290,7 @@ const disableReminderEmbed = (message, reminder) => {
 const disableReminderEmbedWhenRoleIsDeleted = () => {
   const embed = {
     title: "Reminder disabled!",
-    description: "The reminder role has been deleted, reminder is temporarily disabled. To recreate the role, simply re-enable a reminder by typing `$yagi-remind enable`.",
+    description: "The reminder role has been deleted; reminder is temporarily disabled and existing reactions are cleared. To recreate the role, simply re-enable a reminder by typing `$yagi-remind enable`.",
     color: 16711680
   }
   return embed;
@@ -301,7 +301,7 @@ const disableReminderEmbedWhenRoleIsDeleted = () => {
 const disableReminderEmbedWhenReactionIsDeleted = () => {
   const embed = {
     title: "Reminder disabled!",
-    description: "The reaction message has been deleted, reminder is temporarily disabled. To recreate the reaction message, simply re-enable a reminder by typing `$yagi-remind enable`.",
+    description: "The reaction message has been deleted; reminder is temporarily disabled and existing reactions are cleared. To recreate the reaction message, simply re-enable a reminder by typing `$yagi-remind enable`.",
     color: 16711680
   }
   return embed;
@@ -358,6 +358,10 @@ const reminderInstructions = () => {
       {
         name: "How to disable",
         value: "1. Type `$yagi-remind disable` in the channel where reminders was enabled. This will deactivate reminders on the current channel."
+      },
+      {
+        name: 'Deleting Reminder Role/Reaction Message',
+        value: '1. If the reminder role or the reaction message gets deleted, any active reminders will be temporarily disabled\n2. Reactions will also be cleared and existing users would lose the role\n3. Re-enabling a reminder would recreate the deleted role/reaction message and users can react again to get the role'
       }
     ]
   }


### PR DESCRIPTION
#### Context
Update content for help, contacts and info commands. Also created a new `feedback` command that houses the typeform and support server link

#### Change
- Create feedback command
- Add feedback and remind to help command
- Update info and contacts content
- Add deleted role/reaction message info to help command

#### Release Notes
Update commands content