### PR TITLE
Reminder tweaks

### DIFF
--- a/commands/timer/goats.js
+++ b/commands/timer/goats.js
@@ -14,6 +14,7 @@ const {
   startOfDay,
   endOfDay
 } = require('date-fns');
+const sqlite = require('sqlite3').verbose();
 //----------
 /**
  * GET request to spreadsheet for values
@@ -204,12 +205,12 @@ const generateEmbed = function generateWorldBossEmbedToSend(worldBossData) {
         },
         {
           name: 'Countdown',
-          value: '```xl\n\n' + validateSpawn(worldBossData, getServerTime()).countdown + '```',
+          value: '```xl\n\n' + validatedSpawn.countdown + '```',
           inline: true
         },
         {
           name: 'Time of Spawn',
-          value: '```xl\n\n' + validateSpawn(worldBossData, getServerTime()).nextSpawn + '```',
+          value: '```xl\n\n' + validatedSpawn.nextSpawn + '```',
           inline: true
         }
       ]
@@ -223,8 +224,15 @@ const generateEmbed = function generateWorldBossEmbedToSend(worldBossData) {
  * Passed in another function as a parameter so it gets called after everything else is done
  * */
 const sendMessage = function sendMessageToUser(message, embedData) {
-  const embed = embedData;
-  message.channel.send({ embed });
+  let embed = embedData;
+  let database = new sqlite.Database('./database/yagi.db', sqlite.OPEN_READWRITE);
+
+  database.get(`SELECT * FROM Reminder WHERE guild_id = "${message.guild.id}" AND enabled = ${true}`, (error, reminder) => {
+    if(!reminder && embed.color === 32896){
+      embed.description = embed.description + "\n\n*Try out [reminders](https://github.com/vexuas/yagi#setting-up-reminders) to get notified automatically!*"
+    }
+    message.channel.send({ embed });
+  })
 };
 //----------
 module.exports = {

--- a/helpers.js
+++ b/helpers.js
@@ -340,7 +340,7 @@ const enableReminderEmbed = (message, reminder) => {
  */
 const reminderInstructions = () => {
   const embed = {
-    description: "Personal reminder to notify you when world boss is spawning soon.\nCan only be activated in one channel per server by an admin.\n\n",
+    description: "Personal reminder to notify you when world boss is spawning soon.\nCan only be activated in one channel per server by an admin.\n\nVisual guides: [Github](https://github.com/vexuas/yagi#setting-up-reminders) | Youtube",
     color: 32896,
     thumbnail: {
       url:

--- a/yagi.js
+++ b/yagi.js
@@ -19,8 +19,7 @@ const activitylist = [
   'goats | Olympus wb',
   'help | command list',
   'remind | wb reminder notification',
-  'Last update: 27/07/2021',
-  'checkout Ama for eidolons!',
+  'Last update: 27/07/2021'
 ];
 let mixpanel;
 //----------


### PR DESCRIPTION
#### Context
Just added some changes to better rep reminders so more people get exposed to it. As goats is the main command people use, I've added a link for users to see how to set up reminders. As I don't want to overwhelm and potentially annoy, only showing this link when their server doesn't have any active reminders currently.

![image](https://user-images.githubusercontent.com/42207245/127478858-ff896115-0515-478e-a1dd-b576415a5bba.png)

#### Change
- Add reminder link to goats message if server doesn't have any active reminders
- Remove ama description from activity list
- Add github link to remind help

#### Release Notes
Add link to set up reminders in goats command if server doesn't have any current active reminders