### PR TITLE
Remove reply when wrong command

### DIFF
--- a/yagi.js
+++ b/yagi.js
@@ -273,8 +273,6 @@ yagi.on('message', async (message) => {
           await commands[command].execute(message, arguments, yagi, commands, yagiPrefix);
           sendMixpanelEvent(message.author, message.channel, message.channel.guild, command, mixpanel, arguments); //Send tracking event to mixpanel
         }
-      } else {
-        await message.channel.send("I'm not sure what you meant by that! （・□・；）");
       }
     } else {
       return;


### PR DESCRIPTION
#### Context
Removing this to lessen clutter. Also since I want to apply yagi to top.gg and from what I can remember from ama, they rejected her application when this was a thing back then

#### Change
- Remove reply when inputting wrong command with prefix

#### Release Notes
Remove reply when wrong command