### PR TITLE
Release/2021 10 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+# v2.6.0 (Sun Oct 17 2021)
+
+### Release Notes
+
+#### Remove beta information of reminder ([#85](https://github.com/vexuas/yagi/pull/85))
+
+Remove beta information of reminder
+
+#### Clean up code and links ([#84](https://github.com/vexuas/yagi/pull/84))
+
+Clean up code and links
+
+#### Remove reply when wrong command ([#83](https://github.com/vexuas/yagi/pull/83))
+
+Remove reply when wrong command
+
+---
+
+#### 🚀 Enhancement
+
+- Remove beta information of reminder [#85](https://github.com/vexuas/yagi/pull/85) ([@vexuas](https://github.com/vexuas))
+- Clean up code and links [#84](https://github.com/vexuas/yagi/pull/84) ([@vexuas](https://github.com/vexuas))
+- Remove reply when wrong command [#83](https://github.com/vexuas/yagi/pull/83) ([@vexuas](https://github.com/vexuas))
+
+#### 🏠 Internal
+
+- Release/2021 07 29 [#82](https://github.com/vexuas/yagi/pull/82) ([@vexuas](https://github.com/vexuas))
+
+#### Authors: 1
+
+- Gabriel R ([@vexuas](https://github.com/vexuas))
+
+---
+
 # v2.5.1 (Thu Jul 29 2021)
 
 ### Release Notes

--- a/commands/hub/release.js
+++ b/commands/hub/release.js
@@ -4,7 +4,7 @@ module.exports = {
   execute(message) {
     const release = '```FINALLY REMINDERSSSSSS```';
     const embed = {
-      description: `${message.author} | Latest Release: [v2.5.0](https://github.com/Vexuas/yagi/releases)\n${release}`,
+      description: `${message.author} | Latest Release: [v2.6.0](https://github.com/Vexuas/yagi/releases)\n${release}`,
       color: 32896,
     };
     message.channel.send({ embed });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yagi",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Vulture's Vale/Blizzard Berg World Boss Timer for Aura Kingdom",
   "main": "yagi.js",
   "author": "Vexuas",

--- a/yagi.js
+++ b/yagi.js
@@ -19,7 +19,7 @@ const activitylist = [
   'goats | Olympus wb',
   'help | command list',
   'remind | wb reminder notification',
-  'Last update: 27/07/2021'
+  'Last update: 17/10/2021'
 ];
 let mixpanel;
 //----------


### PR DESCRIPTION
# v2.6.0 (Sun Oct 17 2021)

#### 🚀 Enhancement

- Remove beta information of reminder [#85](https://github.com/vexuas/yagi/pull/85) ([@vexuas](https://github.com/vexuas))
- Clean up code and links [#84](https://github.com/vexuas/yagi/pull/84) ([@vexuas](https://github.com/vexuas))
- Remove reply when wrong command [#83](https://github.com/vexuas/yagi/pull/83) ([@vexuas](https://github.com/vexuas))

#### 🏠 Internal

- Release/2021 07 29 [#82](https://github.com/vexuas/yagi/pull/82) ([@vexuas](https://github.com/vexuas))

#### Authors: 1

- Gabriel R ([@vexuas](https://github.com/vexuas))

---