### PR TITLE
Add delete guild handlers

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -71,3 +71,20 @@ exports.insertNewGuild = async (newGuild, yagi, existingClient) => {
     }
   }
 };
+exports.deleteGuild = async (existingGuild, yagi) => {
+  const client = await pool.connect();
+  if (client) {
+    try {
+      await client.query('BEGIN');
+      const deleteGuildQuery = 'DELETE from Guild WHERE uuid = ($1)';
+      await client.query(deleteGuildQuery, [existingGuild.id]);
+      await client.query('COMMIT');
+      await sendGuildUpdateNotification(yagi, existingGuild, 'leave');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      console.log(error);
+    } finally {
+      client.release();
+    }
+  }
+};

--- a/helpers.js
+++ b/helpers.js
@@ -150,10 +150,14 @@ const serverEmbed = async function designOfEmbedForShowingYagiJoiningAndLeavingS
       {
         name: 'Name',
         value: guild.name,
+        inline: true,
       },
       {
         name: 'Owner',
-        value: await guild.members.fetch(guild.ownerId).then((guildMember) => guildMember.user.tag),
+        value:
+          status === 'join'
+            ? await guild.members.fetch(guild.ownerId).then((guildMember) => guildMember.user.tag)
+            : '-',
         inline: true,
       },
       {

--- a/yagi.js
+++ b/yagi.js
@@ -25,7 +25,7 @@ const { sendMixpanelEvent } = require('./analytics');
 const { AutoPoster } = require('topgg-autoposter');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
-const { createGuildTable, insertNewGuild } = require('./database');
+const { createGuildTable, insertNewGuild, deleteGuild } = require('./database');
 
 const rest = new REST({ version: '9' }).setToken(token);
 
@@ -105,9 +105,9 @@ yagi.on('guildCreate', async (guild) => {
     sendErrorLog(yagi, e);
   }
 });
-yagi.on('guildDelete', (guild) => {
+yagi.on('guildDelete', async (guild) => {
   try {
-    //TODO: Add remove guild handler here
+    await deleteGuild(guild, yagi);
   } catch (e) {
     sendErrorLog(yagi, e);
   }


### PR DESCRIPTION
#### Context
Missed this when I switched to postgres which resulted in no handling of existing guild data when they leave. We don't really want to keep this data so I've added the relevant handlers to remove them when this happens

<img width="484" alt="image" src="https://user-images.githubusercontent.com/42207245/222918743-65e6462a-be1b-4f8a-abe0-73c21c5ba02a.png">

#### Change
- Add delete guild handlers

#### Considerations
I've noticed I haven't been writing comments. Not sure if it's cuz I'm just lazy or it makes so much sense to me that I don't need to put it. I'll leave them as it is for now and chalk it up as me getting in the flow of things and not wanting to get slowed down
