### PR TITLE
Update invite link for application commands

### DIFF
--- a/commands/hub/invite/index.js
+++ b/commands/hub/invite/index.js
@@ -7,7 +7,7 @@ module.exports = {
   async execute({ interaction }) {
     try {
       const embed = {
-        description: `<@${interaction.user.id}> | [Add me to your servers! (◕ᴗ◕✿)](https://tinyurl.com/yagi-invite)`,
+        description: `<@${interaction.user.id}> | [Add me to your servers! (◕ᴗ◕✿)](https://discord.com/api/oauth2/authorize?client_id=518196430104428579&permissions=805309456&scope=bot)`,
         color: 32896,
       };
       await interaction.reply({ embeds: [embed] });

--- a/yagi.js
+++ b/yagi.js
@@ -123,7 +123,7 @@ yagi.on('messageCreate', async (message) => {
   if (message.author.bot) return; //Ignore messages made by yagi
 
   const embed = {
-    description: `Yagi no longer supports prefix commands and instead uses Slash Commands now.\nFor example: \`${defaultPrefix}goats\` -> \`/goats\`.\n\nTo see the full list of commands, use \`/help\``,
+    description: `Yagi no longer supports prefix commands and instead uses Slash Commands now.\nFor example: \`${defaultPrefix}goats\` -> \`/goats\`.\n\nTo see the full list of commands, use \`/help\`\n\nIf you can't see the commands in your server, [reinvite Yagi with this link](https://discord.com/api/oauth2/authorize?client_id=518196430104428579&permissions=805309456&scope=bot) as it needs extra scope and permissions`,
     color: 32896,
   };
   try {


### PR DESCRIPTION
#### Context
This updates Yagi's invite links to be able to use application commands. Tho looking at discord's documentation with this, apparently the bot scope already has application commands built in; adding the latter won't really have any use unless you're not creating a bot user. The extra permissions I've added is mostly what I think I'll need for the remind feature revamp

<img width="469" alt="image" src="https://user-images.githubusercontent.com/42207245/222944340-e21e192c-c085-4ee5-ac12-7fc0a3221b5e.png">
<img width="492" alt="image" src="https://user-images.githubusercontent.com/42207245/222944349-6607f7a7-a63f-4946-8cd0-fa872889a7af.png">
<img width="599" alt="image" src="https://user-images.githubusercontent.com/42207245/222944479-7d4990a3-48fb-4fad-98fe-cd914eb267e1.png">

#### Change
- Update invite links with extra scope and permissions
