### PR TITLE
Use webhooks for guild notifications

### DIFF
--- a/events/guildCreate/index.js
+++ b/events/guildCreate/index.js
@@ -1,7 +1,7 @@
 const { WebhookClient } = require('discord.js');
 const { webhooks } = require('../../config/yagi.json');
 const { insertNewGuild } = require('../../services/database');
-const { sendErrorLog, serverEmbed } = require('../../utils/helpers');
+const { sendErrorLog, serverEmbed, checkIfInDevelopment } = require('../../utils/helpers');
 
 /**
  * Event handlers for when yagi is invited to a new server
@@ -12,7 +12,11 @@ module.exports = ({ yagi }) => {
     try {
       await insertNewGuild(guild);
       const embed = await serverEmbed(yagi, guild, 'join');
-      const notificationWebhook = new WebhookClient({ url: webhooks.guildNotifcation.devURL });
+      const notificationWebhook = new WebhookClient({
+        url: checkIfInDevelopment(yagi)
+          ? webhooks.guildNotifcation.devURL
+          : webhooks.guildNotifcation.prodURL,
+      });
       await notificationWebhook.send({
         embeds: [embed],
         username: 'Yagi Server Notificaiton',

--- a/events/guildCreate/index.js
+++ b/events/guildCreate/index.js
@@ -1,7 +1,7 @@
 const { WebhookClient } = require('discord.js');
 const { webhooks } = require('../../config/yagi.json');
 const { insertNewGuild } = require('../../services/database');
-const { sendErrorLog } = require('../../utils/helpers');
+const { sendErrorLog, serverEmbed } = require('../../utils/helpers');
 
 /**
  * Event handlers for when yagi is invited to a new server
@@ -11,9 +11,10 @@ module.exports = ({ yagi }) => {
   yagi.on('guildCreate', async (guild) => {
     try {
       await insertNewGuild(guild, yagi);
+      const embed = await serverEmbed(yagi, guild, 'join');
       const notificationWebhook = new WebhookClient({ url: webhooks.guildNotifcation.devURL });
       await notificationWebhook.send({
-        content: 'this is a guild notification',
+        embeds: [embed],
         username: 'Yagi Server Notificaiton',
         avatarURL:
           'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png',

--- a/events/guildCreate/index.js
+++ b/events/guildCreate/index.js
@@ -1,3 +1,5 @@
+const { WebhookClient } = require('discord.js');
+const { webhooks } = require('../../config/yagi.json');
 const { insertNewGuild } = require('../../services/database');
 const { sendErrorLog } = require('../../utils/helpers');
 
@@ -9,6 +11,13 @@ module.exports = ({ yagi }) => {
   yagi.on('guildCreate', async (guild) => {
     try {
       await insertNewGuild(guild, yagi);
+      const notificationWebhook = new WebhookClient({ url: webhooks.guildNotifcation.devURL });
+      await notificationWebhook.send({
+        content: 'this is a guild notification',
+        username: 'Yagi Server Notificaiton',
+        avatarURL:
+          'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png',
+      });
     } catch (e) {
       sendErrorLog(yagi, e);
     }

--- a/events/guildCreate/index.js
+++ b/events/guildCreate/index.js
@@ -10,7 +10,7 @@ const { sendErrorLog, serverEmbed } = require('../../utils/helpers');
 module.exports = ({ yagi }) => {
   yagi.on('guildCreate', async (guild) => {
     try {
-      await insertNewGuild(guild, yagi);
+      await insertNewGuild(guild);
       const embed = await serverEmbed(yagi, guild, 'join');
       const notificationWebhook = new WebhookClient({ url: webhooks.guildNotifcation.devURL });
       await notificationWebhook.send({

--- a/events/guildDelete/index.js
+++ b/events/guildDelete/index.js
@@ -1,5 +1,7 @@
+const { WebhookClient } = require('discord.js');
+const { webhooks } = require('../../config/yagi.json');
 const { deleteGuild } = require('../../services/database');
-const { sendErrorLog } = require('../../utils/helpers');
+const { sendErrorLog, serverEmbed } = require('../../utils/helpers');
 
 /**
  * Event handlers for when yagi is kickined from a server
@@ -9,6 +11,14 @@ module.exports = ({ yagi }) => {
   yagi.on('guildDelete', async (guild) => {
     try {
       await deleteGuild(guild, yagi);
+      const embed = await serverEmbed(yagi, guild, 'leave');
+      const notificationWebhook = new WebhookClient({ url: webhooks.guildNotifcation.devURL });
+      await notificationWebhook.send({
+        embeds: [embed],
+        username: 'Yagi Server Notificaiton',
+        avatarURL:
+          'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png',
+      });
     } catch (e) {
       sendErrorLog(yagi, e);
     }

--- a/events/guildDelete/index.js
+++ b/events/guildDelete/index.js
@@ -12,7 +12,11 @@ module.exports = ({ yagi }) => {
     try {
       await deleteGuild(guild, yagi);
       const embed = await serverEmbed(yagi, guild, 'leave');
-      const notificationWebhook = new WebhookClient({ url: webhooks.guildNotifcation.devURL });
+      const notificationWebhook = new WebhookClient({
+        url: checkIfInDevelopment(yagi)
+          ? webhooks.guildNotifcation.devURL
+          : webhooks.guildNotifcation.prodURL,
+      });
       await notificationWebhook.send({
         embeds: [embed],
         username: 'Yagi Server Notificaiton',

--- a/services/database.js
+++ b/services/database.js
@@ -61,7 +61,7 @@ exports.insertNewGuild = async (newGuild, yagi, existingClient) => {
         newGuild.ownerId,
       ]);
       await client.query('COMMIT');
-      await sendGuildUpdateNotification(yagi, newGuild, 'join');
+      // await sendGuildUpdateNotification(yagi, newGuild, 'join');
     } catch (error) {
       await client.query('ROLLBACK');
       console.log(error);

--- a/services/database.js
+++ b/services/database.js
@@ -1,6 +1,5 @@
 const { Pool } = require('pg');
 const { databaseConfig } = require('../config/database');
-const { sendGuildUpdateNotification } = require('../utils/helpers');
 const pool = new Pool(databaseConfig);
 
 exports.createGuildTable = async (guildsOfYagi, yagi) => {
@@ -47,7 +46,7 @@ exports.getGuilds = async () => {
     }
   }
 };
-exports.insertNewGuild = async (newGuild, yagi, existingClient) => {
+exports.insertNewGuild = async (newGuild, existingClient) => {
   let client = existingClient ? existingClient : await pool.connect();
   if (client) {
     try {
@@ -61,7 +60,6 @@ exports.insertNewGuild = async (newGuild, yagi, existingClient) => {
         newGuild.ownerId,
       ]);
       await client.query('COMMIT');
-      // await sendGuildUpdateNotification(yagi, newGuild, 'join');
     } catch (error) {
       await client.query('ROLLBACK');
       console.log(error);
@@ -71,7 +69,7 @@ exports.insertNewGuild = async (newGuild, yagi, existingClient) => {
     }
   }
 };
-exports.deleteGuild = async (existingGuild, yagi) => {
+exports.deleteGuild = async (existingGuild) => {
   const client = await pool.connect();
   if (client) {
     try {
@@ -79,7 +77,6 @@ exports.deleteGuild = async (existingGuild, yagi) => {
       const deleteGuildQuery = 'DELETE from Guild WHERE uuid = ($1)';
       await client.query(deleteGuildQuery, [existingGuild.id]);
       await client.query('COMMIT');
-      await sendGuildUpdateNotification(yagi, existingGuild, 'leave');
     } catch (error) {
       await client.query('ROLLBACK');
       console.log(error);


### PR DESCRIPTION
#### Context
Arguably a nice to have but this has always been in my todo list. Don't really want to rely on using the bot to send message notifications. It's way better to use webhooks instead as they're primarily great in these types of usage. 

Could have made it more reusable but I'm just speedrunning through this codebase at this point, don't really want to spend much more time here and move to other projects

<img width="501" alt="image" src="https://user-images.githubusercontent.com/42207245/224470157-bb0cd9d0-6d43-430c-93ce-c6752dd48bd4.png">

#### Change
- Create base webhook clients for listeners
- Send notification when leaving and joining through webooks

#### Considerations
Probably should figure out a better way to check if the server is used for development. Might need to look at .envs at some point
