### PR TITLE
Refactor environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 node_modules
 
 # config
-src/config/yagi.json
-src/config/psa.json
 src/config/database.js
 src/config/ca-certificate.cer
 src/config/environment.js

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ src/config/yagi.json
 src/config/psa.json
 src/config/database.js
 src/config/ca-certificate.cer
+src/config/environment.js
 
 # system files
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "discord-api-types": "^0.37.0",
     "discord.js": "^13.3.1",
     "googleapis": "39",
+    "lodash": "^4.17.21",
     "mixpanel": "^0.13.0",
     "mocha": "^6.2.0",
     "nodemon": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "mocha",
     "start": "yarn nodemon src/yagi.js",
+    "start:prod": "BOT_ENV=prod yarn nodemon src/yagi.js",
     "auto:changelog": "yarn auto changelog",
     "auto:version": "yarn version --`auto version`",
     "auto:release": "yarn auto:changelog && yarn auto:version",

--- a/src/commands/goats/index.js
+++ b/src/commands/goats/index.js
@@ -1,5 +1,4 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const { api } = require('../../config/yagi.json');
 const { google } = require('googleapis');
 const sheets = google.sheets('v4');
 const {
@@ -19,6 +18,7 @@ const {
   startOfDay,
   endOfDay,
 } = require('date-fns');
+const { GOOGLE_CLIENT_ID } = require('../../config/environment');
 //----------
 /**
  * GET request to spreadsheet for values
@@ -32,7 +32,7 @@ const getWorldBossData = async function requestToExternalSpreadsheetAndReturnRea
   interaction,
   sendMessageCallback
 ) {
-  const authClient = api;
+  const authClient = GOOGLE_CLIENT_ID;
   const request = {
     spreadsheetId: 'tUL0-Nn3Jx7e6uX3k4_yifQ',
 

--- a/src/events/guildCreate/index.js
+++ b/src/events/guildCreate/index.js
@@ -1,4 +1,5 @@
 const { WebhookClient } = require('discord.js');
+const { isEmpty } = require('lodash');
 const { GUILD_NOTIFICATION_WEBHOOK_URL } = require('../../config/environment');
 const { insertNewGuild } = require('../../services/database');
 const { sendErrorLog, serverEmbed } = require('../../utils/helpers');
@@ -11,14 +12,16 @@ module.exports = ({ yagi }) => {
   yagi.on('guildCreate', async (guild) => {
     try {
       await insertNewGuild(guild);
-      const embed = await serverEmbed(yagi, guild, 'join');
-      const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });
-      await notificationWebhook.send({
-        embeds: [embed],
-        username: 'Yagi Server Notificaiton',
-        avatarURL:
-          'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png',
-      });
+      if (GUILD_NOTIFICATION_WEBHOOK_URL && !isEmpty(GUILD_NOTIFICATION_WEBHOOK_URL)) {
+        const embed = await serverEmbed(yagi, guild, 'join');
+        const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });
+        await notificationWebhook.send({
+          embeds: [embed],
+          username: 'Yagi Server Notificaiton',
+          avatarURL:
+            'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png',
+        });
+      }
     } catch (e) {
       sendErrorLog(yagi, e);
     }

--- a/src/events/guildCreate/index.js
+++ b/src/events/guildCreate/index.js
@@ -1,7 +1,7 @@
 const { WebhookClient } = require('discord.js');
-const { webhooks } = require('../../config/yagi.json');
+const { GUILD_NOTIFICATION_WEBHOOK_URL } = require('../../config/environment');
 const { insertNewGuild } = require('../../services/database');
-const { sendErrorLog, serverEmbed, checkIfInDevelopment } = require('../../utils/helpers');
+const { sendErrorLog, serverEmbed } = require('../../utils/helpers');
 
 /**
  * Event handlers for when yagi is invited to a new server
@@ -12,11 +12,7 @@ module.exports = ({ yagi }) => {
     try {
       await insertNewGuild(guild);
       const embed = await serverEmbed(yagi, guild, 'join');
-      const notificationWebhook = new WebhookClient({
-        url: checkIfInDevelopment(yagi)
-          ? webhooks.guildNotifcation.devURL
-          : webhooks.guildNotifcation.prodURL,
-      });
+      const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });
       await notificationWebhook.send({
         embeds: [embed],
         username: 'Yagi Server Notificaiton',

--- a/src/events/guildDelete/index.js
+++ b/src/events/guildDelete/index.js
@@ -1,5 +1,5 @@
 const { WebhookClient } = require('discord.js');
-const { webhooks } = require('../../config/yagi.json');
+const { GUILD_NOTIFICATION_WEBHOOK_URL } = require('../../config/environment');
 const { deleteGuild } = require('../../services/database');
 const { sendErrorLog, serverEmbed } = require('../../utils/helpers');
 
@@ -12,11 +12,7 @@ module.exports = ({ yagi }) => {
     try {
       await deleteGuild(guild, yagi);
       const embed = await serverEmbed(yagi, guild, 'leave');
-      const notificationWebhook = new WebhookClient({
-        url: checkIfInDevelopment(yagi)
-          ? webhooks.guildNotifcation.devURL
-          : webhooks.guildNotifcation.prodURL,
-      });
+      const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });
       await notificationWebhook.send({
         embeds: [embed],
         username: 'Yagi Server Notificaiton',

--- a/src/events/guildDelete/index.js
+++ b/src/events/guildDelete/index.js
@@ -1,4 +1,5 @@
 const { WebhookClient } = require('discord.js');
+const { isEmpty } = require('lodash');
 const { GUILD_NOTIFICATION_WEBHOOK_URL } = require('../../config/environment');
 const { deleteGuild } = require('../../services/database');
 const { sendErrorLog, serverEmbed } = require('../../utils/helpers');
@@ -11,14 +12,16 @@ module.exports = ({ yagi }) => {
   yagi.on('guildDelete', async (guild) => {
     try {
       await deleteGuild(guild, yagi);
-      const embed = await serverEmbed(yagi, guild, 'leave');
-      const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });
-      await notificationWebhook.send({
-        embeds: [embed],
-        username: 'Yagi Server Notificaiton',
-        avatarURL:
-          'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png',
-      });
+      if (GUILD_NOTIFICATION_WEBHOOK_URL && !isEmpty(GUILD_NOTIFICATION_WEBHOOK_URL)) {
+        const embed = await serverEmbed(yagi, guild, 'leave');
+        const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });
+        await notificationWebhook.send({
+          embeds: [embed],
+          username: 'Yagi Server Notificaiton',
+          avatarURL:
+            'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png',
+        });
+      }
     } catch (e) {
       sendErrorLog(yagi, e);
     }

--- a/src/events/interactionCreate/index.js
+++ b/src/events/interactionCreate/index.js
@@ -7,13 +7,14 @@ module.exports = ({ yagi, appCommands, mixpanel }) => {
     if (interaction.isCommand()) {
       const { commandName } = interaction;
       await appCommands[commandName].execute({ interaction, yagi });
-      sendMixpanelEvent({
-        user: interaction.user,
-        channel: interaction.channel,
-        guild: interaction.guild,
-        command: commandName,
-        client: mixpanel,
-      }); //Send tracking event to mixpanel
+      mixpanel &&
+        sendMixpanelEvent({
+          user: interaction.user,
+          channel: interaction.channel,
+          guild: interaction.guild,
+          command: commandName,
+          client: mixpanel,
+        }); //Send tracking event to mixpanel
     }
   });
 };

--- a/src/events/messageCreate/index.js
+++ b/src/events/messageCreate/index.js
@@ -1,4 +1,4 @@
-const { defaultPrefix } = require('../../config/yagi.json');
+const { DEFAULT_PREFIX } = require('../../config/environment');
 const { sendErrorLog } = require('../../utils/helpers');
 
 /**
@@ -8,7 +8,7 @@ const { sendErrorLog } = require('../../utils/helpers');
  */
 module.exports = ({ yagi }) => {
   yagi.on('messageCreate', async (message) => {
-    const yagiPrefix = defaultPrefix;
+    const yagiPrefix = DEFAULT_PREFIX;
     if (message.author.bot) return; //Ignore messages made by yagi
 
     const embed = {

--- a/src/events/ready/index.js
+++ b/src/events/ready/index.js
@@ -1,4 +1,3 @@
-const { token, guildIDs } = require('../../config/yagi.json');
 const { Routes } = require('discord-api-types/v9');
 const { REST } = require('@discordjs/rest');
 const { createGuildTable } = require('../../services/database');
@@ -10,8 +9,9 @@ const {
   sendHealthLog,
   checkIfInDevelopment,
 } = require('../../utils/helpers');
+const { BOT_TOKEN, GUILD_IDS } = require('../../config/environment');
 
-const rest = new REST({ version: '9' }).setToken(token);
+const rest = new REST({ version: '9' }).setToken(BOT_TOKEN);
 const activitylist = [
   '/about | bot information',
   '/goats | Olympus wb',
@@ -77,7 +77,7 @@ module.exports = ({ yagi, appCommands }) => {
 
     try {
       if (isInDevelopment) {
-        await rest.put(Routes.applicationGuildCommands('929421200797626388', guildIDs), {
+        await rest.put(Routes.applicationGuildCommands('929421200797626388', GUILD_IDS), {
           body: commandList,
         });
         console.log('Successfully registered guild application commands');

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -21,8 +21,8 @@ const {
 } = require('date-fns');
 const { v4: uuidv4 } = require('uuid');
 const { currentOffset } = require('../config/offset.json');
-const { api } = require('../config/yagi.json');
 const { google } = require('googleapis');
+const { GOOGLE_CLIENT_ID } = require('../config/environment');
 const sheets = google.sheets('v4');
 const grvAcnt = '`';
 
@@ -261,7 +261,7 @@ const generateUUID = () => {
  * auth: an authenticated token you can get from google's sheet api; as the sheet is public you can pretty much use any
  */
 const getWorldBossData = async () => {
-  const authClient = api;
+  const authClient = GOOGLE_CLIENT_ID;
   const request = {
     spreadsheetId: 'tUL0-Nn3Jx7e6uX3k4_yifQ',
 

--- a/src/yagi.js
+++ b/src/yagi.js
@@ -14,9 +14,13 @@ const { isEmpty } = require('lodash');
  * Wrapped in an async function as we want to wait for the promise to end so that our mixpanel instance knows which project to initialize in
  */
 const initialize = async () => {
-  await yagi.login(BOT_TOKEN);
-  const mixpanel = Mixpanel.init(MIXPANEL_ID);
-  !isEmpty(TOP_GG_TOKEN) && AutoPoster(TOP_GG_TOKEN, yagi);
-  registerEventHandlers({ yagi, mixpanel });
+  try {
+    await yagi.login(BOT_TOKEN);
+    const mixpanel = MIXPANEL_ID && !isEmpty(MIXPANEL_ID) && Mixpanel.init(MIXPANEL_ID);
+    TOP_GG_TOKEN && !isEmpty(TOP_GG_TOKEN) && AutoPoster(TOP_GG_TOKEN, yagi);
+    registerEventHandlers({ yagi, mixpanel });
+  } catch (error) {
+    console.log(error);
+  }
 };
 initialize();

--- a/src/yagi.js
+++ b/src/yagi.js
@@ -7,8 +7,10 @@ const Mixpanel = require('mixpanel');
 const { AutoPoster } = require('topgg-autoposter');
 const { registerEventHandlers } = require('./events/events.js');
 const { checkIfInDevelopment } = require('./utils/helpers');
+const { defaultPrefix } = require('./config/environment');
 let mixpanel;
 
+console.log(defaultPrefix);
 //----------
 /**
  * Initialize yagi to log in and establish a connection to Discord

--- a/src/yagi.js
+++ b/src/yagi.js
@@ -6,6 +6,7 @@ const Mixpanel = require('mixpanel');
 const { AutoPoster } = require('topgg-autoposter');
 const { registerEventHandlers } = require('./events/events.js');
 const { BOT_TOKEN, MIXPANEL_ID, TOP_GG_TOKEN } = require('./config/environment');
+const { isEmpty } = require('lodash');
 
 //----------
 /**
@@ -15,7 +16,7 @@ const { BOT_TOKEN, MIXPANEL_ID, TOP_GG_TOKEN } = require('./config/environment')
 const initialize = async () => {
   await yagi.login(BOT_TOKEN);
   const mixpanel = Mixpanel.init(MIXPANEL_ID);
-  TOP_GG_TOKEN.length !== 0 && AutoPoster(TOP_GG_TOKEN, yagi);
+  !isEmpty(TOP_GG_TOKEN) && AutoPoster(TOP_GG_TOKEN, yagi);
   registerEventHandlers({ yagi, mixpanel });
 };
 initialize();

--- a/src/yagi.js
+++ b/src/yagi.js
@@ -1,25 +1,21 @@
 const Discord = require('discord.js');
-const { token, bisoMixpanel, yagiMixpanel, topggToken } = require('./config/yagi.json');
 const yagi = new Discord.Client({
   intents: [Discord.Intents.FLAGS.GUILDS, Discord.Intents.FLAGS.GUILD_MESSAGES],
 });
 const Mixpanel = require('mixpanel');
 const { AutoPoster } = require('topgg-autoposter');
 const { registerEventHandlers } = require('./events/events.js');
-const { checkIfInDevelopment } = require('./utils/helpers');
-const { defaultPrefix } = require('./config/environment');
-let mixpanel;
+const { BOT_TOKEN, MIXPANEL_ID, TOP_GG_TOKEN } = require('./config/environment');
 
-console.log(defaultPrefix);
 //----------
 /**
  * Initialize yagi to log in and establish a connection to Discord
  * Wrapped in an async function as we want to wait for the promise to end so that our mixpanel instance knows which project to initialize in
  */
 const initialize = async () => {
-  await yagi.login(token);
-  mixpanel = Mixpanel.init(checkIfInDevelopment(yagi) ? bisoMixpanel : yagiMixpanel);
-  !checkIfInDevelopment(yagi) && AutoPoster(topggToken, yagi);
+  await yagi.login(BOT_TOKEN);
+  const mixpanel = Mixpanel.init(MIXPANEL_ID);
+  TOP_GG_TOKEN.length !== 0 && AutoPoster(TOP_GG_TOKEN, yagi);
   registerEventHandlers({ yagi, mixpanel });
 };
 initialize();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2244,7 +2244,7 @@ lodash.uniqwith@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz#7a0cbf65f43b5928625a9d4d0dc54b18cadc7ef3"
   integrity sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==
 
-lodash@^4.17.15:
+lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
#### Context
Previously I used to differentiate between a test bot and a production one using a function that checks the currently logged in bot id. This works albeit there's a lot of clutter in the codebase calling this one function. Instead of this, I've refactored the instantiation of environment variables using a mix of exported variables and a passed in argument in the command line

Definitely is more readable and easier to start a project using this approach. Didn't push the environment file but it's in the format of:
```
if(env === 'prod'){
  return {
    BOT_TOKEN: 'this is a prod token',
    ...
  }
}
return {
  BOT_TOKEN: 'this is a dev token',
  ...
}
```

#### Change
- Create environment file
- Replace old config variables