### PR TITLE
Add auto config and license

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,57 @@
+{
+  "baseBranch": "develop",
+  "labels": [
+    {
+      "name": "major",
+      "changelogTitle": "💥 Breaking Change",
+      "description": "Increment the major version when merged",
+      "releaseType": "major"
+    },
+    {
+      "name": "enhancement",
+      "changelogTitle": "🚀 Enhancement",
+      "description": "Increment the minor version when merged",
+      "releaseType": "minor"
+    },
+    {
+      "name": "bugs",
+      "changelogTitle": "🐛 Fixes",
+      "description": "For bug fixes. Increments the patch version when merged",
+      "releaseType": "patch"
+    },
+    {
+      "name": "tests",
+      "changelogTitle": "Tests",
+      "description": "Changes only affect tests. Increments the patch version when merged",
+      "releaseType": "patch"
+    },
+    {
+      "name": "tweaks",
+      "changelogTitle": "🔧 Tweaks",
+      "description": "For stuff that should increment the patch, but aren't bug fixes or tests i.e. copy changes, minor styling updates. Increments the patch version when merged",
+      "releaseType": "patch"
+    },
+    {
+      "name": "skip-release",
+      "description": "Preserve the current version when merged",
+      "releaseType": "skip"
+    },
+    {
+      "name": "release",
+      "description": "Create a release when this pr is merged",
+      "releaseType": "release"
+    },
+    {
+      "name": "internal",
+      "changelogTitle": "🏠 Internal",
+      "description": "Changes only affect the internal API",
+      "releaseType": "none"
+    },
+    {
+      "name": "documentation",
+      "changelogTitle": "📝 Documentation",
+      "description": "Changes only affect the documentation",
+      "releaseType": "none"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Vulture's Vale/Blizzard Berg World Boss Timer for Aura Kingdom",
   "main": "yagi.js",
   "author": "Vexuas",
+  "license": "MIT",
   "scripts": {
-    "start": "yarn prebuild && yarn build && yarn build:watch",
+    "start": "yarn build && yarn build:watch",
     "start:prod": "yarn prebuild && yarn build && BOT_ENV=prod yarn node dist/yagi.js",
     "prebuild": "node -p \"'export const BOT_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "build": "tsc",


### PR DESCRIPTION
#### Context
Yoinking the auto config from another place and using it here since it's way better than the default auto labels. Added an MIT license as well since my terminal kept complaining that my package is missing it

#### Change
- Add license
- Add autorc

