### PR TITLE
Release/2023 04 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# v3.2.3 (Mon Apr 17 2023)
+
+#### 🏠 Internal
+
+- Release/2023 04 09 [#134](https://github.com/vexuas/yagi/pull/134) ([@vexuas](https://github.com/vexuas))
+
+#### 🔩 Dependency Updates
+
+- Bump node-fetch from 2.6.1 to 2.6.7 [#143](https://github.com/vexuas/yagi/pull/143) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+- Upgrade googleapis [#142](https://github.com/vexuas/yagi/pull/142) ([@vexuas](https://github.com/vexuas))
+- Upgrade auto [#141](https://github.com/vexuas/yagi/pull/141) ([@vexuas](https://github.com/vexuas))
+- Remove nodemon [#140](https://github.com/vexuas/yagi/pull/140) ([@vexuas](https://github.com/vexuas))
+- Bump http-cache-semantics from 4.1.0 to 4.1.1 [#139](https://github.com/vexuas/yagi/pull/139) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+- Bump ansi-regex from 4.1.0 to 4.1.1 [#138](https://github.com/vexuas/yagi/pull/138) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+- Bump qs from 6.10.1 to 6.11.1 [#137](https://github.com/vexuas/yagi/pull/137) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+- Bump undici from 5.8.0 to 5.21.2 [#136](https://github.com/vexuas/yagi/pull/136) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+- Bump minimatch from 3.0.4 to 3.1.2 [#135](https://github.com/vexuas/yagi/pull/135) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+
+#### Authors: 2
+
+- [@dependabot[bot]](https://github.com/dependabot[bot])
+- Gabriel R ([@vexuas](https://github.com/vexuas))
+
+---
+
 # v3.2.2 (Sun Apr 09 2023)
 
 #### 🐛 Bug Fix

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png" width=120px/>
 </div>
 
-# yagi | v3.2.0 <br>Aura Kingdom EN World Boss Timer for Discord
+# yagi | v3.2.3 <br>Aura Kingdom EN World Boss Timer for Discord
 
 Discord bot created for the MMORPG [Aura Kingdom](https://aurakingdom.aeriagames.com/). Its main
 function is to give information of when the next spawn of the world bosses of Vulture's Vale and
@@ -24,10 +24,11 @@ Yagi, thanks a lot I really appreciate it! (◕ᴗ◕✿)
 ## Tech Stack
 
 - [Discord.js](https://discord.js.org/#/) - Node.js module to interact easier with Discord's API
-- [PostgreSQL](https://www.postgresql.org/) | [DigitalOcean](https://www.digitalocean.com/products/managed-databases)  - Managed database to store server data
+- [PostgreSQL](https://www.postgresql.org/) | [DigitalOcean](https://www.digitalocean.com/products/managed-databases) - Managed database to store server data
 - [Mixpanel](https://mixpanel.com/) - user analytics tracker
 
 ## Commands List
+
 Instead of prefixes, Yagi uses Discord's [Slash Commands](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ) `/`
 
 - `goats` - information for the next world boss spawn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yagi",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Vulture's Vale/Blizzard Berg World Boss Timer for Aura Kingdom",
   "main": "yagi.js",
   "author": "Vexuas",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const BOT_VERSION = "3.2.2";export const BOT_UPDATED_AT = "09-Apr-2023"
+export const BOT_VERSION = "3.2.3";export const BOT_UPDATED_AT = "17-Apr-2023"


### PR DESCRIPTION
# v3.2.3 (Mon Apr 17 2023)

#### 🏠 Internal

- Release/2023 04 09 [#134](https://github.com/vexuas/yagi/pull/134) ([@vexuas](https://github.com/vexuas))

#### 🔩 Dependency Updates

- Bump node-fetch from 2.6.1 to 2.6.7 [#143](https://github.com/vexuas/yagi/pull/143) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
- Upgrade googleapis [#142](https://github.com/vexuas/yagi/pull/142) ([@vexuas](https://github.com/vexuas))
- Upgrade auto [#141](https://github.com/vexuas/yagi/pull/141) ([@vexuas](https://github.com/vexuas))
- Remove nodemon [#140](https://github.com/vexuas/yagi/pull/140) ([@vexuas](https://github.com/vexuas))
- Bump http-cache-semantics from 4.1.0 to 4.1.1 [#139](https://github.com/vexuas/yagi/pull/139) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
- Bump ansi-regex from 4.1.0 to 4.1.1 [#138](https://github.com/vexuas/yagi/pull/138) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
- Bump qs from 6.10.1 to 6.11.1 [#137](https://github.com/vexuas/yagi/pull/137) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
- Bump undici from 5.8.0 to 5.21.2 [#136](https://github.com/vexuas/yagi/pull/136) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
- Bump minimatch from 3.0.4 to 3.1.2 [#135](https://github.com/vexuas/yagi/pull/135) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))

#### Authors: 2

- [@dependabot[bot]](https://github.com/dependabot[bot])
- Gabriel R ([@vexuas](https://github.com/vexuas))

---
