### PR TITLE
Handle sheet data when it's erroring out

### DIFF
--- a/src/commands/goats/index.ts
+++ b/src/commands/goats/index.ts
@@ -15,6 +15,7 @@ export type WorldBossData = {
   lastSpawn: string;
   nextSpawn: string;
   countdown: string;
+  hasErrorData?: boolean;
 };
 export interface ValidWorldBossData extends WorldBossData {
   serverTime: string;
@@ -75,7 +76,10 @@ export default {
       await interaction.deferReply();
       const serverTime = getServerTime();
       const worldBossData = await getWorldBossData();
-      console.log(worldBossData);
+      if (worldBossData.hasErrorData) {
+        await interaction.editReply({ content: 'something went wrong with data' });
+        return;
+      }
       const validatedWorldBossData = validateWorldBossData(worldBossData, serverTime);
       const embed = validatedWorldBossData && generateGoatsEmbed(validatedWorldBossData);
       embed && (await interaction.editReply({ embeds: [embed] }));

--- a/src/commands/goats/index.ts
+++ b/src/commands/goats/index.ts
@@ -67,6 +67,15 @@ export const generateGoatsEmbed = (worldBossData: ValidWorldBossData): APIEmbed 
   return embedData;
 };
 
+export const generateGoatsErrorEmbed = (): APIEmbed => {
+  const embed: APIEmbed = {
+    title: 'Olympus | World Boss',
+    description:
+      'Whoops looks like there is an issue in getting the world boss data D:\n\nCheck out the [sheet](https://docs.google.com/spreadsheets/d/tUL0-Nn3Jx7e6uX3k4_yifQ/edit#gid=1990459509) for more information!',
+    color: 32896,
+  };
+  return embed;
+};
 export default {
   data: new SlashCommandBuilder()
     .setName('goats')
@@ -77,7 +86,7 @@ export default {
       const serverTime = getServerTime();
       const worldBossData = await getWorldBossData();
       if (worldBossData.hasErrorData) {
-        await interaction.editReply({ content: 'something went wrong with data' });
+        await interaction.editReply({ embeds: [generateGoatsErrorEmbed()] });
         return;
       }
       const validatedWorldBossData = validateWorldBossData(worldBossData, serverTime);

--- a/src/commands/goats/index.ts
+++ b/src/commands/goats/index.ts
@@ -75,6 +75,7 @@ export default {
       await interaction.deferReply();
       const serverTime = getServerTime();
       const worldBossData = await getWorldBossData();
+      console.log(worldBossData);
       const validatedWorldBossData = validateWorldBossData(worldBossData, serverTime);
       const embed = validatedWorldBossData && generateGoatsEmbed(validatedWorldBossData);
       embed && (await interaction.editReply({ embeds: [embed] }));

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -213,6 +213,7 @@ export const getWorldBossData = async (): Promise<WorldBossData> => {
       lastSpawn: actualSheetValues[1],
       nextSpawn: actualSheetValues[2],
       countdown: actualSheetValues[3],
+      hasErrorData,
     };
   } catch (e) {
     console.log(e);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -207,6 +207,7 @@ export const getWorldBossData = async (): Promise<WorldBossData> => {
       rawSheetValues.forEach((item) => {
         item.values && actualSheetValues.push(item.values[0][0]);
       });
+    const hasErrorData = actualSheetValues.some((value) => !value || value.includes('---'));
     return {
       location: actualSheetValues[0],
       lastSpawn: actualSheetValues[1],


### PR DESCRIPTION
#### Context
Haven't been keeping up with yagi but I stumbled upon the world boss discord server and saw that there were a number of instances where it wasn't responding to interactions. This felt weird since I didn't get any error logs recently; turns out after I did a little digging that somebody nuked the goats so no one has any idea when the goats are spawning. Or at least it's too much of a hassle to fix it. 

This would probably get fixed by the leads in the next maintenance but adding this handler so next time it happens people would at least know that there is an issue with the goat data.

![image](https://user-images.githubusercontent.com/42207245/235365048-17ebe4c3-d9dd-4f97-ae3a-b8b0042c9734.png)

![image](https://user-images.githubusercontent.com/42207245/235364901-3823803a-43a4-4bbf-8e9a-b0cb89151a6c.png)
![image](https://user-images.githubusercontent.com/42207245/235364986-c62c69cd-bcdb-4f0a-8ad3-0d8fc4eae7c3.png)

#### Change
- Check if sheet data has undefined or special character strings
- Return early in command if data has error
- Show error embed when data has error

#### Considerations
A lil bit risky checking every value of the returned sheet values if any of them is undefined or has the special strings. Might be better to just check the specific date cells but this seems okay for now. I'll just monitor if it actually throws mostly false positives.
