### PR TITLE
Release/2024 04 09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# v3.3.0 (Tue Apr 09 2024)
+
+#### 🚀 Enhancement
+
+- Update offset.json for daylights [#156](https://github.com/vexuas/yagi/pull/156) ([@vexuas](https://github.com/vexuas))
+
+#### 🏠 Internal
+
+- Release/2023 06 12 [#149](https://github.com/vexuas/yagi/pull/149) ([@vexuas](https://github.com/vexuas))
+
+#### 🔩 Dependency Updates
+
+- Bump @babel/traverse from 7.21.3 to 7.23.2 [#153](https://github.com/vexuas/yagi/pull/153) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+- Bump undici from 5.21.2 to 5.26.3 [#152](https://github.com/vexuas/yagi/pull/152) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+- Bump word-wrap from 1.2.3 to 1.2.4 [#151](https://github.com/vexuas/yagi/pull/151) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+- Bump semver from 6.3.0 to 6.3.1 [#150](https://github.com/vexuas/yagi/pull/150) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
+
+#### Authors: 2
+
+- [@dependabot[bot]](https://github.com/dependabot[bot])
+- Gabriel R ([@vexuas](https://github.com/vexuas))
+
+---
+
 # v3.2.5 (Mon Jun 12 2023)
 
 #### 🐛 Bug Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yagi",
-  "version": "3.2.5",
+  "version": "3.3.0",
   "description": "Vulture's Vale/Blizzard Berg World Boss Timer for Aura Kingdom",
   "main": "yagi.js",
   "author": "Vexuas",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const BOT_VERSION = "3.2.5";export const BOT_UPDATED_AT = "12-Jun-2023"
+export const BOT_VERSION = "3.3.0";export const BOT_UPDATED_AT = "09-Apr-2024"


### PR DESCRIPTION
# v3.3.0 (Tue Apr 09 2024)

#### 🚀 Enhancement

- Update offset.json for daylights [#156](https://github.com/vexuas/yagi/pull/156) ([@vexuas](https://github.com/vexuas))

#### 🏠 Internal

- Release/2023 06 12 [#149](https://github.com/vexuas/yagi/pull/149) ([@vexuas](https://github.com/vexuas))

#### 🔩 Dependency Updates

- Bump @babel/traverse from 7.21.3 to 7.23.2 [#153](https://github.com/vexuas/yagi/pull/153) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
- Bump undici from 5.21.2 to 5.26.3 [#152](https://github.com/vexuas/yagi/pull/152) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
- Bump word-wrap from 1.2.3 to 1.2.4 [#151](https://github.com/vexuas/yagi/pull/151) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))
- Bump semver from 6.3.0 to 6.3.1 [#150](https://github.com/vexuas/yagi/pull/150) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@vexuas](https://github.com/vexuas))

#### Authors: 2

- [@dependabot[bot]](https://github.com/dependabot[bot])
- Gabriel R ([@vexuas](https://github.com/vexuas))

---
