### PR TITLE
Delete compiled folder before recompiling in deployment workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -39,6 +39,7 @@ jobs:
             echo "${{ secrets.DATABASE_PROD }}" > src/config/database.ts
             yarn update:version
             yarn install
+            rm -R dist
             yarn build
             pm2 start deploy.config.js --env prod
 


### PR DESCRIPTION
#### Context
Typescript caches compiled files that sometimes messes up intended changes; usually when files get deleted. We don't really want this unwanted variable in our deployment process so I'm adding a step to delete the compiled folder. `dist` first before rebuilding

#### Change
- Delete compiled folder before recompiling

#### Considerations
There might be a more elegant way of clearing/bypassing the cache but settling with this for now
