### PR TITLE
Revert back to daylights offset

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -40,14 +40,15 @@ jobs:
             yarn update:version
             yarn install
             rm -R dist
+            export NODE_OPTIONS=--max_old_space_size=4096
             yarn build
             pm2 start deploy.config.js --env prod
 
       - name: Send notification to Discord
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_NOTIFICATION_WEBHOOK }}
-          DISCORD_USERNAME: 'Yagi Release Notification'
-          DISCORD_AVATAR: 'https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png'
+          DISCORD_USERNAME: "Yagi Release Notification"
+          DISCORD_AVATAR: "https://cdn.discordapp.com/attachments/491143568359030794/500863196471754762/goat-timer_logo_dark2.png"
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: 'Successfully deployed `${{ github.ref_name }}` to production'
+          args: "Successfully deployed `${{ github.ref_name }}` to production"

--- a/src/config/offset.json
+++ b/src/config/offset.json
@@ -1,5 +1,5 @@
 {
-  "currentOffset": 5,
+  "currentOffset": 4,
   "start": "9 March 2025",
   "end": "2 Nov 2025",
   "dstOffset": 4,


### PR DESCRIPTION
#### Context
Apparently the game hasn't switched back to normal time even tho it's been 2 months since it ended. Not sure why x-legends hasn't bothered doing it, dunno if this is the norm too moving forward? Idk I'll go check out the game in the coming weeks to see what's up

My last release also died and apparently the build ran out of memory. Not sure why since I'm pretty sure I set it up before to not use the strict default using the solution [here](https://stackoverflow.com/questions/38558989/node-js-heap-out-of-memory). In any case, I've added an extra step to the deploy flow to always set it

#### Change
- Revert to daylights offset
- Increase memory usage on deploy
